### PR TITLE
Update Validator.php

### DIFF
--- a/source/Spiral/Validation/Validator.php
+++ b/source/Spiral/Validation/Validator.php
@@ -330,6 +330,19 @@ class Validator extends Component implements ValidatorInterface, LoggerAwareInte
 
                     return $result;
                 }
+                
+                //If checker does not have registered alias
+                if (class_exists($condition[0])) {
+                    $checker = $this->container->get($condition[0]);
+                    if ($checker instanceof Checker) {
+                        if (!$result = $checker->check($condition[1], $value, $arguments, $this)) {
+                            //To let validation() method know that message should be handled via Checker
+                            return $checker;
+                        }
+
+                        return $result;
+                    }
+                }
             }
 
             if (is_array($condition)) {


### PR DESCRIPTION
If use `MyChecker::class . '::validationMethod'` without adding `MyChecker::class` alias into validation config then we have 2 problems:

1. We can't use default messages
2. We can't use `$this->validator()` inside of a checker