### PR TITLE
Fixes typo in first example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Examples:
 class HomeController extends Controller
 {
     /**
-     * IoC Container can automatically deside what database/cache/storage
+     * IoC Container can automatically decide what database/cache/storage
      * instance to provide for every action parameter based on it's 
      * name or type.
      *


### PR DESCRIPTION
People are easily thrown off by stuff like this. 
It would be a shame because this framework looks very nice at first sight.