### PR TITLE
[Validation Package] Allow validation data to be set directly from an EntityInterface

### DIFF
--- a/source/Spiral/Validation/Validator.php
+++ b/source/Spiral/Validation/Validator.php
@@ -127,6 +127,14 @@ class Validator extends Component implements ValidatorInterface, LoggerAwareInte
     /**
      * {@inheritdoc}
      */
+    public function withDataEntity(EntityInterface $entity) : ValidatorInterface
+    {
+        return $this->setData($entity->getFields());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setRules(array $rules): ValidatorInterface
     {
         if ($this->rules == $rules) {
@@ -243,7 +251,6 @@ class Validator extends Component implements ValidatorInterface, LoggerAwareInte
     {
         $this->errors = [];
         foreach ($this->rules as $field => $rules) {
-
             foreach ($rules as $rule) {
                 if (isset($this->errors[$field])) {
                     //We are validating field till first error

--- a/source/Spiral/Validation/ValidatorInterface.php
+++ b/source/Spiral/Validation/ValidatorInterface.php
@@ -8,6 +8,7 @@
 
 namespace Spiral\Validation;
 
+use Spiral\Models\EntityInterface;
 use Spiral\Validation\Exceptions\ValidationException;
 
 /**
@@ -100,4 +101,11 @@ interface ValidatorInterface
      * @return array
      */
     public function getErrors(): array;
+
+    /**
+     * Update validation data (context) from a data entity.
+     * @param \Spiral\Models\EntityInterface $entity
+     * @return \Spiral\Validation\ValidatorInterface
+     */
+    public function withDataEntity(EntityInterface $entity): ValidatorInterface;
 }

--- a/tests/Validation/ValidatorTest.php
+++ b/tests/Validation/ValidatorTest.php
@@ -11,6 +11,7 @@ namespace Spiral\Tests\Validation;
 use Interop\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Spiral\Debug\LogsInterface;
+use Spiral\Models\DataEntity;
 use Spiral\Tests\Validation\Fixtures\SimpleTestChecker;
 use Spiral\Translator\TranslatorInterface;
 use Spiral\Validation\Checkers\AddressChecker;
@@ -274,6 +275,24 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validator->hasErrors());
 
         $this->assertEquals(['foo' => 'bar'], $validator->setData(['foo' => 'bar'])->getData());
+    }
+
+    public function testSetDataWithAnEntity()
+    {
+        $data = new DataEntity(
+            [
+                "name" => "Spiral",
+                "type" => "Framework",
+                "foo" => "bar"
+            ]
+        );
+
+        $val = new Validator([], [], $this->config, $this->container);
+
+        $validator = $val->withDataEntity($data);
+
+        $this->assertFalse($validator->hasErrors()); //No rules were registered
+        $this->assertEquals($data->getFields(), $validator->getData());
     }
 
     public function testCustomErrors()


### PR DESCRIPTION
This PR allows validation data to be set from a `DataEntity` (or `EntityInterface` to be precise)....

Usecase = >

- Currently 

```php

$data = [];
$data[self::ARGS_FULL_NAME] = $this->argument(self::ARGS_FULL_NAME);
$data[self::ARGS_MONIKER] = $this->argument(self::ARGS_MONIKER);
$data[self::ARGS_EMAIL] = $this->argument(self::ARGS_EMAIL);

$transformedData = new SomeDataEntity($data);

$val->setData($transformedData->getFields());

//Do something else with $transformedData
```

- This PR =>

```php
$validator = $validator->withDataEntity($transformedData);
```

Just sugar syntax, but i have found myself this past hour filling an `EntityInterface` and passing it to the validator.