### PR TITLE
PR Fix validation for more than one sub request

### DIFF
--- a/source/Spiral/Http/Request/InputInterface.php
+++ b/source/Spiral/Http/Request/InputInterface.php
@@ -36,7 +36,9 @@ interface InputInterface
      *
      * @param string $prefix
      *
+     * @param bool $add When set to false current prefix path will be overwritten.
+     *
      * @return InputInterface
      */
-    public function withPrefix(string $prefix): InputInterface;
+    public function withPrefix(string $prefix, bool $add = true): InputInterface;
 }

--- a/source/Spiral/Http/Request/InputManager.php
+++ b/source/Spiral/Http/Request/InputManager.php
@@ -387,10 +387,16 @@ class InputManager implements InputInterface, SingletonInterface
      *
      * @return self
      */
-    public function withPrefix(string $prefix): InputInterface
+    public function withPrefix(string $prefix, bool $add = true): InputInterface
     {
         $input = clone $this;
-        $input->prefix = $prefix;
+
+        if ($add) {
+            $input->prefix .= '.' . $prefix;
+            $input->prefix = trim($input->prefix, '.');
+        } else {
+            $input->prefix = $prefix;
+        }
 
         return $input;
     }

--- a/tests/Http/Fixtures/FirstDepthRequest.php
+++ b/tests/Http/Fixtures/FirstDepthRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spiral\Tests\Http\Fixtures;
+
+use Spiral\Http\Request\RequestFilter;
+
+class FirstDepthRequest extends RequestFilter
+{
+    const SCHEMA = [
+        'first' => SecondDepthRequest::class
+    ];
+}

--- a/tests/Http/Fixtures/SecondDepthRequest.php
+++ b/tests/Http/Fixtures/SecondDepthRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spiral\Tests\Http\Fixtures;
+
+use Spiral\Http\Request\RequestFilter;
+
+class SecondDepthRequest extends RequestFilter
+{
+    const SCHEMA = [
+        'second' => ThirdDepthRequest::class
+    ];
+}

--- a/tests/Http/Fixtures/ThirdDepthRequest.php
+++ b/tests/Http/Fixtures/ThirdDepthRequest.php
@@ -9,4 +9,8 @@ class ThirdDepthRequest extends RequestFilter
     const SCHEMA = [
         'third' => 'data:third'
     ];
+
+    const VALIDATES = [
+        'third' => ['notEmpty']
+    ];
 }

--- a/tests/Http/Fixtures/ThirdDepthRequest.php
+++ b/tests/Http/Fixtures/ThirdDepthRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spiral\Tests\Http\Fixtures;
+
+use Spiral\Http\Request\RequestFilter;
+
+class ThirdDepthRequest extends RequestFilter
+{
+    const SCHEMA = [
+        'third' => 'data:third'
+    ];
+}

--- a/tests/Http/RequestFilters/MultipleDepthRequestTest.php
+++ b/tests/Http/RequestFilters/MultipleDepthRequestTest.php
@@ -39,7 +39,7 @@ class MultipleDepthRequestTest extends HttpTest
         $this->container->bind(ServerRequestInterface::class, $serverRequest);
 
         /** @var DemoRequest $request */
-        $request = $this->container->get(ThirdDepthRequest::class);
+        $request = $this->container->get(FirstDepthRequest::class);
 
         $this->assertTrue($request->isValid());
         $this->assertArrayNotHasKey('first', $request->getErrors());

--- a/tests/Http/RequestFilters/MultipleDepthRequestTest.php
+++ b/tests/Http/RequestFilters/MultipleDepthRequestTest.php
@@ -43,8 +43,6 @@ class MultipleDepthRequestTest extends HttpTest
 
         $this->assertTrue($request->isValid());
         $this->assertArrayNotHasKey('first', $request->getErrors());
-        $this->assertArrayNotHasKey('second', $request->getErrors()['first']);
-        $this->assertArrayNotHasKey('third', $request->getErrors()['first']['second']);
 
         $this->assertArrayHasKey('first', $request->getValidator()->getData());
         $this->assertArrayHasKey('second', $request->getValidator()->getData()['first']);

--- a/tests/Http/RequestFilters/MultipleDepthRequestTest.php
+++ b/tests/Http/RequestFilters/MultipleDepthRequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Spiral\Tests\Http\RequestFilters;
 
 use Psr\Http\Message\ServerRequestInterface;
@@ -22,7 +23,7 @@ class MultipleDepthRequestTest extends HttpTest
         $this->assertFalse($request->isValid());
         $this->assertArrayHasKey('first', $request->getErrors());
         $this->assertArrayHasKey('second', $request->getErrors()['first']);
-        $this->assertArrayHasKey('third', $request->getErrors()['second']);
+        $this->assertArrayHasKey('third', $request->getErrors()['first']['second']);
     }
 
     public function testDataPassed()
@@ -41,7 +42,13 @@ class MultipleDepthRequestTest extends HttpTest
         $request = $this->container->get(ThirdDepthRequest::class);
 
         $this->assertTrue($request->isValid());
-        $this->assertArrayHasKey(['city'], $request->getValidator()->getData()['first']['second']);
+        $this->assertArrayNotHasKey('first', $request->getErrors());
+        $this->assertArrayNotHasKey('second', $request->getErrors()['first']);
+        $this->assertArrayNotHasKey('third', $request->getErrors()['first']['second']);
+
+        $this->assertArrayHasKey('first', $request->getValidator()->getData());
+        $this->assertArrayHasKey('second', $request->getValidator()->getData()['first']);
+        $this->assertArrayHasKey('third', $request->getValidator()->getData()['first']['second']);
         $this->assertSame('3rd value', $request->getValidator()->getData()['first']['second']['third']);
     }
 }

--- a/tests/Http/RequestFilters/MultipleDepthRequestTest.php
+++ b/tests/Http/RequestFilters/MultipleDepthRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace Spiral\Tests\Http\RequestFilters;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Spiral\Tests\Http\Fixtures\DemoRequest;
+use Spiral\Tests\Http\Fixtures\FirstDepthRequest;
+use Spiral\Tests\Http\Fixtures\ThirdDepthRequest;
+use Spiral\Tests\Http\HttpTest;
+use Zend\Diactoros\ServerRequest;
+
+class MultipleDepthRequestTest extends HttpTest
+{
+    public function testHasErrors()
+    {
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withParsedBody([]);
+        $this->container->bind(ServerRequestInterface::class, $serverRequest);
+
+        /** @var DemoRequest $request */
+        $request = $this->container->get(FirstDepthRequest::class);
+
+        $this->assertFalse($request->isValid());
+        $this->assertArrayHasKey('first', $request->getErrors());
+        $this->assertArrayHasKey('second', $request->getErrors()['first']);
+        $this->assertArrayHasKey('third', $request->getErrors()['second']);
+    }
+
+    public function testDataPassed()
+    {
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withParsedBody([
+            'first' => [
+                'second' => [
+                    'third' => '3rd value',
+                ],
+            ]
+        ]);
+        $this->container->bind(ServerRequestInterface::class, $serverRequest);
+
+        /** @var DemoRequest $request */
+        $request = $this->container->get(ThirdDepthRequest::class);
+
+        $this->assertTrue($request->isValid());
+        $this->assertArrayHasKey(['city'], $request->getValidator()->getData()['first']['second']);
+        $this->assertSame('3rd value', $request->getValidator()->getData()['first']['second']['third']);
+    }
+}

--- a/tests/Http/RequestFilters/ScopingTest.php
+++ b/tests/Http/RequestFilters/ScopingTest.php
@@ -35,7 +35,7 @@ class ScopingTest extends BaseTest
                 }
             }
 
-            public function withPrefix(string $prefix): InputInterface
+            public function withPrefix(string $prefix, bool $add = true): InputInterface
             {
                 return $this;
             }


### PR DESCRIPTION
Previously requests couldn't validate more than 2 depth levels (3rd depth level didn't contain any data)