### PR TITLE
Adding the ability to override the base namespace

### DIFF
--- a/src/Reactor/src/Traits/PropertiesAware.php
+++ b/src/Reactor/src/Traits/PropertiesAware.php
@@ -39,7 +39,11 @@ trait PropertiesAware
     /** @param string $name without $ */
     public function addProperty(string $name, mixed $value = null): Property
     {
-        return Property::fromElement($this->element->addProperty($name, $value));
+        if (\func_num_args() > 1) {
+            return Property::fromElement($this->element->addProperty($name, $value));
+        }
+
+        return Property::fromElement($this->element->addProperty($name));
     }
 
     /** @param string $name without $ */

--- a/src/Scaffolder/src/Config/ScaffolderConfig.php
+++ b/src/Scaffolder/src/Config/ScaffolderConfig.php
@@ -48,17 +48,17 @@ class ScaffolderConfig extends InjectableConfig
             $localNamespace .= '\\' . $this->classify($namespace);
         }
 
-        if (empty($this->baseNamespace())) {
+        if (empty($this->baseNamespace($element))) {
             return $localNamespace;
         }
 
-        return \trim($this->baseNamespace() . '\\' . $localNamespace, '\\');
+        return \trim($this->baseNamespace($element) . '\\' . $localNamespace, '\\');
     }
 
     public function classFilename(string $element, string $name): string
     {
         $namespace = $this->classNamespace($element, $name);
-        $namespace = \substr($namespace, \strlen($this->baseNamespace()));
+        $namespace = \substr($namespace, \strlen($this->baseNamespace($element)));
 
         return $this->joinPathChunks([
             $this->baseDirectory(),
@@ -129,8 +129,12 @@ class ScaffolderConfig extends InjectableConfig
         return ['namespace' => '', 'name' => $name];
     }
 
-    private function baseNamespace(): string
+    private function baseNamespace(string $element): string
     {
+        if (\array_key_exists('baseNamespace', $this->config['declarations'][$element])) {
+            return \trim((string) $this->getOption($element, 'baseNamespace', ''), '\\');
+        }
+
         return \trim($this->config['namespace'], '\\');
     }
 

--- a/src/Scaffolder/src/Declaration/AbstractDeclaration.php
+++ b/src/Scaffolder/src/Declaration/AbstractDeclaration.php
@@ -28,6 +28,7 @@ abstract class AbstractDeclaration implements DeclarationInterface
 
         $this->file = new FileDeclaration();
         $this->file->addNamespace($this->namespace);
+        $this->file->setComment($this->config->headerLines());
 
         $this->declare();
     }

--- a/src/Scaffolder/tests/Command/BootloaderTest.php
+++ b/src/Scaffolder/tests/Command/BootloaderTest.php
@@ -40,9 +40,12 @@ class BootloaderTest extends AbstractCommandTest
         $this->assertTrue(class_exists(self::CLASS_NAME));
 
         $reflection = new ReflectionClass(self::CLASS_NAME);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
         $this->assertStringContainsString('Sample Bootloader', $reflection->getDocComment());
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertTrue($reflection->hasMethod('boot'));
 
         $this->assertTrue($reflection->hasConstant('BINDINGS'));

--- a/src/Scaffolder/tests/Command/CommandTest.php
+++ b/src/Scaffolder/tests/Command/CommandTest.php
@@ -43,8 +43,11 @@ class CommandTest extends AbstractCommandTest
         $this->assertTrue(class_exists($className));
 
         $reflection = new ReflectionClass($className);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertTrue($reflection->hasMethod('perform'));
         $this->assertTrue($reflection->hasConstant('NAME'));
         $this->assertTrue($reflection->hasConstant('DESCRIPTION'));

--- a/src/Scaffolder/tests/Command/ConfigTest.php
+++ b/src/Scaffolder/tests/Command/ConfigTest.php
@@ -40,8 +40,11 @@ class ConfigTest extends AbstractCommandTest
         $this->assertTrue(class_exists(self::CLASS_NAME));
 
         $reflection = new ReflectionClass(self::CLASS_NAME);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Config', $reflection->getDocComment());
 
         $this->assertTrue($reflection->hasConstant('CONFIG'));

--- a/src/Scaffolder/tests/Command/ControllerTest.php
+++ b/src/Scaffolder/tests/Command/ControllerTest.php
@@ -36,8 +36,11 @@ class ControllerTest extends AbstractCommandTest
         $this->assertTrue(class_exists($class));
 
         $reflection = new ReflectionClass($class);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Controller', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('index'));
         $this->assertTrue($reflection->hasMethod('save'));

--- a/src/Scaffolder/tests/Command/FilterTest.php
+++ b/src/Scaffolder/tests/Command/FilterTest.php
@@ -49,8 +49,11 @@ class FilterTest extends AbstractCommandTest
         $this->assertTrue(class_exists(self::CLASS_NAME));
 
         $reflection = new ReflectionClass(self::CLASS_NAME);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertSame([
             'name'     => 'data:name',
             'email'    => 'data:email',

--- a/src/Scaffolder/tests/Command/JobHandlerTest.php
+++ b/src/Scaffolder/tests/Command/JobHandlerTest.php
@@ -40,8 +40,11 @@ class JobHandlerTest extends AbstractCommandTest
         $this->assertTrue(class_exists(self::CLASS_NAME));
 
         $reflection = new ReflectionClass(self::CLASS_NAME);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Job Handler', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('invoke'));
     }

--- a/src/Scaffolder/tests/Command/MiddlewareTest.php
+++ b/src/Scaffolder/tests/Command/MiddlewareTest.php
@@ -40,8 +40,11 @@ class MiddlewareTest extends AbstractCommandTest
         $this->assertTrue(class_exists(self::CLASS_NAME));
 
         $reflection = new ReflectionClass(self::CLASS_NAME);
+        $content = $this->files()->read($reflection->getFileName());
 
-        $this->assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
+        $this->assertStringContainsString('strict_types=1', $content);
+        $this->assertStringContainsString('{project-name}', $content);
+        $this->assertStringContainsString('@author {author-name}', $content);
         $this->assertStringContainsString('Sample Middleware', $reflection->getDocComment());
         $this->assertTrue($reflection->hasMethod('process'));
     }

--- a/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
+++ b/src/Scaffolder/tests/Config/ScaffolderConfigTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Scaffolder\Config;
+
+use Spiral\Scaffolder\Bootloader\ScaffolderBootloader;
+use Spiral\Scaffolder\Config\ScaffolderConfig;
+use Spiral\Tests\Scaffolder\BaseTest;
+
+class ScaffolderConfigTest extends BaseTest
+{
+    public function testDefaultBaseNamespace(): void
+    {
+        /** @var ScaffolderBootloader $scaffolder */
+        $scaffolder = $this->app->get(ScaffolderBootloader::class);
+
+        $scaffolder->addDeclaration('changing-namespace', []);
+
+        /** @var ScaffolderConfig $config */
+        $config = $this->app->get(ScaffolderConfig::class);
+
+        $this->assertSame(
+            'Spiral\\Tests\\Scaffolder\\App',
+            (new \ReflectionMethod($config, 'baseNamespace'))->invoke($config, 'changing-namespace')
+        );
+    }
+
+    public function testChangingBaseNamespace(): void
+    {
+        /** @var ScaffolderBootloader $scaffolder */
+        $scaffolder = $this->app->get(ScaffolderBootloader::class);
+
+        $scaffolder->addDeclaration('null-namespace', ['baseNamespace' => null]);
+        $scaffolder->addDeclaration('empty-namespace', ['baseNamespace' => '']);
+        $scaffolder->addDeclaration('overridden-namespace', ['baseNamespace' => 'Test']);
+
+        /** @var ScaffolderConfig $config */
+        $config = $this->app->get(ScaffolderConfig::class);
+
+        $ref = new \ReflectionMethod($config, 'baseNamespace');
+        $this->assertSame('', $ref->invoke($config, 'null-namespace'));
+        $this->assertSame('', $ref->invoke($config, 'empty-namespace'));
+        $this->assertSame('Test', $ref->invoke($config, 'overridden-namespace'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

1) New feature. Previously, allowed to create declarations with the namespace of the application (for example, `Add\Declaration`). 
Now added the ability to override the base namespace (for example, `Declaration`, `OtherNamespace\Declaration`). 
2) Bugfix. Added a missed comment to the declaration file.
3) Bugfix. Fixed adding value to a property in Reactor.
