### PR TITLE
Adding the ability to configure the Attributes cache or disable the cache

### DIFF
--- a/src/Framework/Bootloader/Attributes/AttributesConfig.php
+++ b/src/Framework/Bootloader/Attributes/AttributesConfig.php
@@ -10,14 +10,37 @@ final class AttributesConfig extends InjectableConfig
 {
     public const CONFIG = 'attributes';
 
+    /**
+     * @var array{
+     *     annotations: array{support:bool},
+     *     cache: array{storage: null|non-empty-string, enabled: bool},
+     * }
+     */
     protected array $config = [
         'annotations' => [
             'support' => true,
+        ],
+        'cache' => [
+            'storage' => null,
+            'enabled' => false,
         ],
     ];
 
     public function isAnnotationsReaderEnabled(): bool
     {
         return (bool)$this->config['annotations']['support'];
+    }
+
+    public function isCacheEnabled(): bool
+    {
+        return (bool)($this->config['cache']['enabled'] ?? false);
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getCacheStorage(): ?string
+    {
+        return $this->config['cache']['storage'] ?? null;
     }
 }

--- a/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
@@ -8,6 +8,7 @@ use Spiral\Attributes\Composite\SelectiveReader;
 use Spiral\Attributes\Internal\Instantiator\Facade;
 use Spiral\Attributes\Internal\Instantiator\InstantiatorInterface;
 use Spiral\Attributes\ReaderInterface;
+use Spiral\Bootloader\Attributes\AttributesConfig;
 use Spiral\Bootloader\Attributes\Factory;
 use Spiral\Tests\Framework\BaseTestCase;
 
@@ -21,5 +22,15 @@ final class AttributesBootloaderTest extends BaseTestCase
     public function testInstantiatorBinding(): void
     {
         $this->assertContainerBoundAsSingleton(InstantiatorInterface::class, Facade::class);
+    }
+
+    public function testIsCacheEnabledShouldBeFalse(): void
+    {
+        $this->assertFalse($this->getConfig(AttributesConfig::CONFIG)['cache']['enabled']);
+    }
+
+    public function testGetStorageShouldBeNull(): void
+    {
+        $this->assertNull($this->getConfig(AttributesConfig::CONFIG)['cache']['storage']);
     }
 }

--- a/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Bootloader\Attributes;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Bootloader\Attributes\AttributesConfig;
+
+final class AttributesConfigTest extends TestCase
+{
+    public function testIsAnnotationsReaderEnabled(): void
+    {
+        $this->assertTrue((new AttributesConfig())->isAnnotationsReaderEnabled());
+        $this->assertFalse(
+            (new AttributesConfig(['annotations' => ['support' => false]]))->isAnnotationsReaderEnabled()
+        );
+    }
+
+    public function testIsCacheEnabled(): void
+    {
+        $this->assertFalse((new AttributesConfig())->isCacheEnabled());
+        $this->assertTrue((new AttributesConfig(['cache' => ['enabled' => true]]))->isCacheEnabled());
+    }
+
+    public function testGetCacheStorage(): void
+    {
+        $this->assertNull((new AttributesConfig())->getCacheStorage());
+        $this->assertSame(
+            'test',
+            (new AttributesConfig(['cache' => ['storage' => 'test']]))->getCacheStorage()
+        );
+    }
+}

--- a/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
@@ -13,31 +13,22 @@ use Spiral\Tests\Framework\BaseTestCase;
 
 final class AttributesWithoutAnnotationsBootloaderTest extends BaseTestCase
 {
-    public const MAKE_APP_ON_STARTUP = false;
-
     #[Env('SUPPORT_ANNOTATIONS', 'false')]
     public function testReaderBindingWithoutCache(): void
     {
-        $this
-            ->withDisabledBootloaders(\Spiral\Cache\Bootloader\CacheBootloader::class)
-            ->initApp($this->getTestEnvVariables());
-
         $this->assertContainerBoundAsSingleton(ReaderInterface::class, AttributeReader::class);
     }
 
     #[Env('SUPPORT_ANNOTATIONS', 'false')]
-    public function testReaderBindingWithtCache(): void
+    #[Env('ATTRIBUTES_CACHE_ENABLED', 'true')]
+    public function testReaderBindingWithCache(): void
     {
-        $this->initApp($this->getTestEnvVariables());
-
         $this->assertContainerBoundAsSingleton(ReaderInterface::class, Psr16CachedReader::class);
     }
 
     #[Env('SUPPORT_ANNOTATIONS', 'true')]
     public function testSelectiveReaderBinding(): void
     {
-        $this->initApp($this->getTestEnvVariables());
-
         $this->assertContainerBoundAsSingleton(ReaderInterface::class, SelectiveReader::class);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### What was changed

A new **cache** section with **enabled** and **storage** settings has been added to the `attributes.php` configuration file.

```php
return [
    // ...
    'cache' => [
        'storage' => env('ATTRIBUTES_CACHE_STORAGE', 'file'),
        'enabled' => env('ATTRIBUTES_CACHE_ENABLED', true),
    ],
];
```
**The cache is disabled by default because, since Framework v3.8.0, a connection error is displayed if the RoadRunner cache is used and RoadRunner is not running.**
