### PR TITLE
Parse command input parameter

### DIFF
--- a/src/Console/src/Attribute/AsInput.php
+++ b/src/Console/src/Attribute/AsInput.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spiral\Console\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class AsInput
+{
+}

--- a/src/Console/src/Configurator/Attribute/Parser.php
+++ b/src/Console/src/Configurator/Attribute/Parser.php
@@ -8,6 +8,7 @@ use Spiral\Attributes\AttributeReader;
 use Spiral\Attributes\ReaderInterface;
 use Spiral\Console\Attribute\Argument;
 use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\AsInput;
 use Spiral\Console\Attribute\Option;
 use Spiral\Console\Command;
 use Spiral\Console\Configurator\CommandDefinition;
@@ -41,10 +42,12 @@ final class Parser
             $attribute = $reflection->getAttributes(SymfonyAsCommand::class)[0]->newInstance();
         }
 
+        $parseSourceReflection = $this->getParseSource($reflection);
+
         return new CommandDefinition(
             name: $attribute->name,
-            arguments: $this->parseArguments($reflection),
-            options: $this->parseOptions($reflection),
+            arguments: $this->parseArguments($parseSourceReflection),
+            options: $this->parseOptions($parseSourceReflection),
             description: $attribute->description,
             help: $attribute instanceof AsCommand ? $attribute->help : null
         );
@@ -82,6 +85,39 @@ final class Parser
                 }
             }
         }
+    }
+
+    /**
+     * Get the method that should be used to parse the command.
+     *
+     * This either can be the command itself, of the `#[AsInput]` parameter of the `perform` or `__invoke` method.
+     */
+    private function getParseSource(\ReflectionClass $reflection): \ReflectionClass
+    {
+        $method = $reflection->hasMethod('perform')
+            ? $reflection->getMethod('perform')
+            : ($reflection->hasMethod('__invoke')
+                ? $reflection->getMethod('__invoke')
+                : null);
+
+        if ($method === null) {
+            return $reflection;
+        }
+
+        $parameter = null;
+        foreach ($method->getParameters() as $param) {
+            $attribute = $this->reader->firstParameterMetadata($param, AsInput::class);
+            if ($attribute !== null) {
+                $parameter = $param;
+                break;
+            }
+        }
+
+        if ($parameter === null) {
+            return $reflection;
+        }
+
+        return new \ReflectionClass($parameter->getType()->getName());
     }
 
     private function parseArguments(\ReflectionClass $reflection): array

--- a/src/Console/tests/Configurator/Attribute/InputSourceTest.php
+++ b/src/Console/tests/Configurator/Attribute/InputSourceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spiral\Tests\Console\Configurator\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\Factory;
+use Spiral\Console\Configurator\Attribute\Parser;
+use Spiral\Tests\Console\Fixtures\Attribute\WithInvokeInputParameterCommand;
+use Spiral\Tests\Console\Fixtures\Attribute\WithPerformInputParameterCommand;
+
+class InputSourceTest extends TestCase
+{
+    private Parser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new Parser((new Factory())->create());
+    }
+
+    public function testWithInvokeMethod(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(WithInvokeInputParameterCommand::class));
+
+        self::assertNotEmpty($result->arguments);
+        self::assertNotEmpty($result->options);
+    }
+
+    public function testWithPerformMethod(): void
+    {
+        $result = $this->parser->parse(new \ReflectionClass(WithPerformInputParameterCommand::class));
+
+        self::assertNotEmpty($result->arguments);
+        self::assertNotEmpty($result->options);
+    }
+}

--- a/src/Console/tests/Fixtures/Attribute/Input/InputSource.php
+++ b/src/Console/tests/Fixtures/Attribute/Input/InputSource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spiral\Tests\Console\Fixtures\Attribute\Input;
+
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\Option;
+
+class InputSource
+{
+    #[Argument]
+    private string $arg;
+
+    #[Option]
+    private int $opt;
+}

--- a/src/Console/tests/Fixtures/Attribute/WithInvokeInputParameterCommand.php
+++ b/src/Console/tests/Fixtures/Attribute/WithInvokeInputParameterCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spiral\Tests\Console\Fixtures\Attribute;
+
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\AsInput;
+use Spiral\Console\Command;
+use Spiral\Tests\Console\Fixtures\Attribute\Input\InputSource;
+
+#[AsCommand(name: 'attribute-with-description', description: 'Some description text')]
+final class WithInvokeInputParameterCommand extends Command
+{
+    public function __invoke(#[AsInput] InputSource $input): int
+    {
+        $this->write($this->getDescription());
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/tests/Fixtures/Attribute/WithPerformInputParameterCommand.php
+++ b/src/Console/tests/Fixtures/Attribute/WithPerformInputParameterCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spiral\Tests\Console\Fixtures\Attribute;
+
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\AsInput;
+use Spiral\Console\Command;
+use Spiral\Tests\Console\Fixtures\Attribute\Input\InputSource;
+
+#[AsCommand(name: 'attribute-with-description', description: 'Some description text')]
+final class WithPerformInputParameterCommand extends Command
+{
+    public function perform(#[AsInput] InputSource $input): int
+    {
+        $this->write($this->getDescription());
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | N/A <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

### ToDo

- [ ] `promptMissedArguments` & `getQuestion`
- [ ] Add Changelog
- [ ] Add to docs

This feature is a logical continuation of https://spiral.dev/docs/cookbook-console-validation/current. If this PR is merged, it will now be allowed to configure attributes and options inside the Filter class without the need to duplicate fields and signature.

Currently, this PR is just a showcase of its features and implementation examples. I am willing to rework this PR as needed.

```diff
class UserRegisterFilter extends Filter
{
+    #[Argument(description: 'User username')]
    public string $username;

+    #[Argument(description: 'User email address')]
+    #[Question('Provide a valid email for the user')]
    public string $email;

+    #[Option(description: 'Mark as admin')]
    public bool $admin = false;

+    #[Option(key: 'send-verification-email', description: 'Send a verification email to the user')]
    public bool $sendVerificationEmail = false;
}

+#[AsCommand(user:register)]
final class UserRegister extends Command
{
-    protected const SIGNATURE = <<<CMD
-        user:register
-        {username : User username}
-        {email : User email address}
-        {--a|admin : Mark as admin}
-        {--s|send-verification-email : Send a verification email to the user}
-CMD;

-    public function perform(UserRegisterFilter $input): int
+    public function perform(#[AsInput] UserRegisterFilter $input): int
    {
        // ...

        return self::SUCCESS;
    }
}
```

