### PR TITLE
Document Paginator and harden limit handling

### DIFF
--- a/src/Exceptions/src/Renderer/ConsoleRenderer.php
+++ b/src/Exceptions/src/Renderer/ConsoleRenderer.php
@@ -246,7 +246,7 @@ class ConsoleRenderer extends AbstractRenderer
 
         try {
             if (\DIRECTORY_SEPARATOR === '\\') {
-                return (\function_exists('sapi_windows_vt100_support') && @\sapi_windows_vt100_support($stream))
+                return (\function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support($stream))
                     || \getenv('ANSICON') !== false
                     || \getenv('ConEmuANSI') === 'ON'
                     || \getenv('TERM') === 'xterm';

--- a/src/Exceptions/src/Renderer/ConsoleRenderer.php
+++ b/src/Exceptions/src/Renderer/ConsoleRenderer.php
@@ -246,7 +246,7 @@ class ConsoleRenderer extends AbstractRenderer
 
         try {
             if (\DIRECTORY_SEPARATOR === '\\') {
-                return (\function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support($stream))
+                return (\function_exists('sapi_windows_vt100_support') && @\sapi_windows_vt100_support($stream))
                     || \getenv('ANSICON') !== false
                     || \getenv('ConEmuANSI') === 'ON'
                     || \getenv('TERM') === 'xterm';

--- a/src/Pagination/src/Paginator.php
+++ b/src/Pagination/src/Paginator.php
@@ -10,8 +10,7 @@ namespace Spiral\Pagination;
  * Example usage:
  *
  *     $perPage = 100;
- *     $paginator = (new Paginator($perPage))
- *         ->paginate($select);
+ *     $paginator = new Paginator($perPage, $select->count());
  *     for ($page = 1; $page <= $paginator->countPages(); $page++) {
  *         $paginator
  *             ->withPage($page)
@@ -21,20 +20,35 @@ namespace Spiral\Pagination;
  */
 final class Paginator implements PaginatorInterface, \Countable
 {
-    /** Current page number (1-based, clamped to valid range on read). */
+    /**
+     * Current page number (1-based, clamped to valid range on read).
+     *
+     * @var positive-int
+     */
     private int $pageNumber = 1;
 
-    /** Total number of pages, derived from $count and $limit. */
+    /**
+     * Total number of pages, derived from $count and $limit.
+     *
+     * @var positive-int
+     */
     private int $countPages = 1;
 
-    /** Total number of items across all pages. */
+    /**
+     * Total number of items across all pages.
+     *
+     * @var int<0, max>
+     */
     private int $count;
 
+    /**
+     * @param positive-int $limit Maximum items per page.
+     * @param int<0, max> $count Total number of items.
+     * @param string|null $parameter Query parameter name used to read the current page from the environment (e.g. "page").
+     */
     public function __construct(
-        /** Maximum items per page. */
         private int $limit = 25,
         int $count = 0,
-        /** Query parameter name used to read the current page from the environment (e.g. "page"). */
         private readonly ?string $parameter = null,
     ) {
         $this->setCount($count);
@@ -48,6 +62,9 @@ final class Paginator implements PaginatorInterface, \Countable
         return $this->parameter;
     }
 
+    /**
+     * @param positive-int $limit
+     */
     public function withLimit(int $limit): self
     {
         $paginator = clone $this;
@@ -56,6 +73,9 @@ final class Paginator implements PaginatorInterface, \Countable
         return $paginator;
     }
 
+    /**
+     * @return positive-int
+     */
     public function getLimit(): int
     {
         return $this->limit;
@@ -64,26 +84,34 @@ final class Paginator implements PaginatorInterface, \Countable
     public function withPage(int $number): self
     {
         $paginator = clone $this;
-        $paginator->pageNumber = \max($number, 0);
+        $paginator->pageNumber = \max($number, 1);
 
         //Real page number
         return $paginator;
     }
 
+    /**
+     * @param int<0, max> $count
+     */
     public function withCount(int $count): self
     {
         return (clone $this)->setCount($count);
     }
 
+    /**
+     * @return positive-int
+     */
     public function getPage(): int
     {
         return match (true) {
-            $this->pageNumber < 1 => 1,
             $this->pageNumber > $this->countPages => $this->countPages,
             default => $this->pageNumber,
         };
     }
 
+    /**
+     * @return int<0, max>
+     */
     public function getOffset(): int
     {
         return ($this->getPage() - 1) * $this->limit;
@@ -102,20 +130,29 @@ final class Paginator implements PaginatorInterface, \Countable
         return $paginator;
     }
 
+    /**
+     * @return int<0, max>
+     */
     public function count(): int
     {
         return $this->count;
     }
 
+    /**
+     * @return positive-int
+     */
     public function countPages(): int
     {
         return $this->countPages;
     }
 
+    /**
+     * @return int<0, max>
+     */
     public function countDisplayed(): int
     {
         if ($this->getPage() === $this->countPages) {
-            return $this->count - $this->getOffset();
+            return \max(0, $this->count - $this->getOffset());
         }
 
         return $this->limit;
@@ -126,6 +163,9 @@ final class Paginator implements PaginatorInterface, \Countable
         return ($this->countPages > 1);
     }
 
+    /**
+     * @return positive-int|null
+     */
     public function nextPage(): ?int
     {
         if ($this->getPage() !== $this->countPages) {
@@ -135,10 +175,14 @@ final class Paginator implements PaginatorInterface, \Countable
         return null;
     }
 
+    /**
+     * @return positive-int|null
+     */
     public function previousPage(): ?int
     {
-        if ($this->getPage() > 1) {
-            return $this->getPage() - 1;
+        $page = $this->getPage();
+        if ($page > 1) {
+            return $page - 1;
         }
 
         return null;
@@ -146,6 +190,9 @@ final class Paginator implements PaginatorInterface, \Countable
 
     /**
      * Non-Immutable version of withCount.
+     *
+     * @param int<0, max> $count
+     * @return static
      */
     private function setCount(int $count): self
     {

--- a/src/Pagination/src/Paginator.php
+++ b/src/Pagination/src/Paginator.php
@@ -51,6 +51,7 @@ final class Paginator implements PaginatorInterface, \Countable
         int $count = 0,
         private readonly ?string $parameter = null,
     ) {
+        $this->limit = \max($this->limit, 1);
         $this->setCount($count);
     }
 
@@ -68,7 +69,9 @@ final class Paginator implements PaginatorInterface, \Countable
     public function withLimit(int $limit): self
     {
         $paginator = clone $this;
-        $paginator->limit = $limit;
+        $paginator->limit = \max($limit, 1);
+        // $countPages is derived from $count and $limit, so it must be recomputed.
+        $paginator->setCount($paginator->count);
 
         return $paginator;
     }

--- a/src/Pagination/src/Paginator.php
+++ b/src/Pagination/src/Paginator.php
@@ -6,16 +6,35 @@ namespace Spiral\Pagination;
 
 /**
  * Simple predictable paginator.
+ *
+ * Example usage:
+ *
+ *     $perPage = 100;
+ *     $paginator = (new Paginator($perPage))
+ *         ->paginate($select);
+ *     for ($page = 1; $page <= $paginator->countPages(); $page++) {
+ *         $paginator
+ *             ->withPage($page)
+ *             ->paginate($select);
+ *         yield $this->toCSVLine($this->toRows($select->fetchData()));
+ *     }
  */
 final class Paginator implements PaginatorInterface, \Countable
 {
+    /** Current page number (1-based, clamped to valid range on read). */
     private int $pageNumber = 1;
+
+    /** Total number of pages, derived from $count and $limit. */
     private int $countPages = 1;
+
+    /** Total number of items across all pages. */
     private int $count;
 
     public function __construct(
+        /** Maximum items per page. */
         private int $limit = 25,
         int $count = 0,
+        /** Query parameter name used to read the current page from the environment (e.g. "page"). */
         private readonly ?string $parameter = null,
     ) {
         $this->setCount($count);

--- a/src/Pagination/tests/PaginatorTest.php
+++ b/src/Pagination/tests/PaginatorTest.php
@@ -41,6 +41,33 @@ class PaginatorTest extends TestCase
         self::assertSame(4, $paginator->countPages());
     }
 
+    public function testWithLimitRecomputesCountPages(): void
+    {
+        $paginator = new Paginator(limit: 25, count: 100);
+        self::assertSame(4, $paginator->countPages());
+
+        $paginator = $paginator->withLimit(10);
+
+        self::assertSame(10, $paginator->getLimit());
+        self::assertSame(10, $paginator->countPages());
+    }
+
+    public function testWithLimitClampsToPositive(): void
+    {
+        $paginator = (new Paginator(limit: 25, count: 100))->withLimit(0);
+
+        self::assertSame(1, $paginator->getLimit());
+        self::assertSame(100, $paginator->countPages());
+    }
+
+    public function testZeroLimitInConstructorDoesNotDivideByZero(): void
+    {
+        $paginator = new Paginator(limit: 0, count: 5);
+
+        self::assertSame(1, $paginator->getLimit());
+        self::assertSame(5, $paginator->countPages());
+    }
+
     public function testCountsAndPages(): void
     {
         $paginator = new Paginator(limit: 25);


### PR DESCRIPTION
Adds PHPDoc types and a usage example to `Paginator`, plus a fixed usage snippet.

Hardens limit handling: `withLimit()` now recomputes `countPages`, and `limit` is clamped to `>= 1` (constructor + `withLimit`) to prevent a `DivisionByZeroError`. Adds regression tests.