### PR TITLE
Fix CsrfMiddleware cookie missing Path attribute

### DIFF
--- a/src/Csrf/src/Config/CsrfConfig.php
+++ b/src/Csrf/src/Config/CsrfConfig.php
@@ -15,6 +15,7 @@ final class CsrfConfig extends InjectableConfig
         'length' => 16,
         'lifetime' => null,
         'sameSite' => null,
+        'path' => null,
     ];
 
     public function getTokenLength(): int
@@ -40,5 +41,14 @@ final class CsrfConfig extends InjectableConfig
     public function getSameSite(): ?string
     {
         return $this->config['sameSite'];
+    }
+
+    /**
+     * Explicit cookie path override. When null the {@see CsrfMiddleware} falls back to
+     * {@see \Spiral\Http\Config\HttpConfig::getBasePath()}, matching the session cookie scope.
+     */
+    public function getCookiePath(): ?string
+    {
+        return $this->config['path'] ?? null;
     }
 }

--- a/src/Csrf/src/Config/CsrfConfig.php
+++ b/src/Csrf/src/Config/CsrfConfig.php
@@ -45,6 +45,8 @@ final class CsrfConfig extends InjectableConfig
 
     public function getCookiePath(): string
     {
-        return $this->config['path'] ?? '/';
+        // Normalize null/empty to "/": an empty path makes Cookie::createHeader() omit the
+        // Path= attribute, which reintroduces the fragmented-cookie bug this option prevents.
+        return ($this->config['path'] ?? '') ?: '/';
     }
 }

--- a/src/Csrf/src/Config/CsrfConfig.php
+++ b/src/Csrf/src/Config/CsrfConfig.php
@@ -15,7 +15,7 @@ final class CsrfConfig extends InjectableConfig
         'length' => 16,
         'lifetime' => null,
         'sameSite' => null,
-        'path' => null,
+        'path' => '/',
     ];
 
     public function getTokenLength(): int
@@ -43,12 +43,8 @@ final class CsrfConfig extends InjectableConfig
         return $this->config['sameSite'];
     }
 
-    /**
-     * Explicit cookie path override. When null the {@see CsrfMiddleware} falls back to
-     * {@see \Spiral\Http\Config\HttpConfig::getBasePath()}, matching the session cookie scope.
-     */
-    public function getCookiePath(): ?string
+    public function getCookiePath(): string
     {
-        return $this->config['path'] ?? null;
+        return $this->config['path'] ?? '/';
     }
 }

--- a/src/Csrf/src/Middleware/CsrfMiddleware.php
+++ b/src/Csrf/src/Middleware/CsrfMiddleware.php
@@ -10,6 +10,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Cookies\Cookie;
 use Spiral\Csrf\Config\CsrfConfig;
+use Spiral\Http\Config\HttpConfig;
 
 /**
  * Provides generic CSRF protection using cookie as token storage. Set "csrfToken" attribute to
@@ -25,6 +26,7 @@ final class CsrfMiddleware implements MiddlewareInterface
 
     public function __construct(
         private readonly CsrfConfig $config,
+        private readonly ?HttpConfig $httpConfig = null,
     ) {}
 
     public function process(Request $request, RequestHandlerInterface $handler): Response
@@ -59,12 +61,23 @@ final class CsrfMiddleware implements MiddlewareInterface
             $this->config->getCookie(),
             $token,
             $this->config->getCookieLifetime(),
-            null,
+            $this->cookiePath(),
             null,
             $this->config->isCookieSecure(),
             true,
             $this->config->getSameSite(),
         )->createHeader();
+    }
+
+    /**
+     * Resolve the cookie path. An explicit csrf config value wins; otherwise fall back to the
+     * application base path (same scope as the session cookie), defaulting to "/".
+     */
+    private function cookiePath(): string
+    {
+        return $this->config->getCookiePath()
+            ?? $this->httpConfig?->getBasePath()
+            ?? '/';
     }
 
     /**

--- a/src/Csrf/src/Middleware/CsrfMiddleware.php
+++ b/src/Csrf/src/Middleware/CsrfMiddleware.php
@@ -10,7 +10,6 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Cookies\Cookie;
 use Spiral\Csrf\Config\CsrfConfig;
-use Spiral\Http\Config\HttpConfig;
 
 /**
  * Provides generic CSRF protection using cookie as token storage. Set "csrfToken" attribute to
@@ -26,7 +25,6 @@ final class CsrfMiddleware implements MiddlewareInterface
 
     public function __construct(
         private readonly CsrfConfig $config,
-        private readonly ?HttpConfig $httpConfig = null,
     ) {}
 
     public function process(Request $request, RequestHandlerInterface $handler): Response
@@ -61,23 +59,12 @@ final class CsrfMiddleware implements MiddlewareInterface
             $this->config->getCookie(),
             $token,
             $this->config->getCookieLifetime(),
-            $this->cookiePath(),
+            $this->config->getCookiePath(),
             null,
             $this->config->isCookieSecure(),
             true,
             $this->config->getSameSite(),
         )->createHeader();
-    }
-
-    /**
-     * Resolve the cookie path. An explicit csrf config value wins; otherwise fall back to the
-     * application base path (same scope as the session cookie), defaulting to "/".
-     */
-    private function cookiePath(): string
-    {
-        return $this->config->getCookiePath()
-            ?? $this->httpConfig?->getBasePath()
-            ?? '/';
     }
 
     /**

--- a/src/Csrf/tests/ConfigTest.php
+++ b/src/Csrf/tests/ConfigTest.php
@@ -35,6 +35,6 @@ class ConfigTest extends TestCase
         self::assertNull($c->getCookieLifetime());
         self::assertTrue($c->isCookieSecure());
         self::assertNull($c->getSameSite());
-        self::assertNull($c->getCookiePath());
+        self::assertSame('/', $c->getCookiePath());
     }
 }

--- a/src/Csrf/tests/ConfigTest.php
+++ b/src/Csrf/tests/ConfigTest.php
@@ -37,4 +37,16 @@ class ConfigTest extends TestCase
         self::assertNull($c->getSameSite());
         self::assertSame('/', $c->getCookiePath());
     }
+
+    public function testEmptyCookiePathFallsBackToRoot(): void
+    {
+        $c = new CsrfConfig([
+            'cookie' => 'csrf-token',
+            'length' => 16,
+            'path'   => '',
+        ]);
+
+        // An empty path would make Cookie::createHeader() drop the Path= attribute.
+        self::assertSame('/', $c->getCookiePath());
+    }
 }

--- a/src/Csrf/tests/ConfigTest.php
+++ b/src/Csrf/tests/ConfigTest.php
@@ -16,6 +16,7 @@ class ConfigTest extends TestCase
             'length'   => 16,
             'lifetime' => 86400,
             'sameSite' => 'Lax',
+            'path'     => '/admin',
         ]);
 
         self::assertSame('csrf-token', $c->getCookie());
@@ -23,6 +24,7 @@ class ConfigTest extends TestCase
         self::assertSame(86400, $c->getCookieLifetime());
         self::assertFalse($c->isCookieSecure());
         self::assertSame('Lax', $c->getSameSite());
+        self::assertSame('/admin', $c->getCookiePath());
 
         $c = new CsrfConfig([
             'cookie' => 'csrf-token',
@@ -33,5 +35,6 @@ class ConfigTest extends TestCase
         self::assertNull($c->getCookieLifetime());
         self::assertTrue($c->isCookieSecure());
         self::assertNull($c->getSameSite());
+        self::assertNull($c->getCookiePath());
     }
 }

--- a/src/Csrf/tests/CsrfTest.php
+++ b/src/Csrf/tests/CsrfTest.php
@@ -78,6 +78,31 @@ final class CsrfTest extends TestCase
         self::assertStringContainsString('Path=/admin', $this->fetchSetCookie($response, 'csrf-token'));
     }
 
+    public function testEmptyConfiguredPathStillEmitsPathAttribute(): void
+    {
+        $this->container->bind(
+            CsrfConfig::class,
+            new CsrfConfig(
+                [
+                    'cookie'   => 'csrf-token',
+                    'length'   => 16,
+                    'lifetime' => 86400,
+                    'path'     => '',
+                ],
+            ),
+        );
+
+        $core = $this->httpCore([CsrfMiddleware::class]);
+        $core->setHandler(
+            static fn($r) => $r->getAttribute(CsrfMiddleware::ATTRIBUTE),
+        );
+
+        $response = $this->get($core, '/feature/123');
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertStringContainsString('Path=/', $this->fetchSetCookie($response, 'csrf-token'));
+    }
+
     public function testLengthException(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/src/Csrf/tests/CsrfTest.php
+++ b/src/Csrf/tests/CsrfTest.php
@@ -53,22 +53,7 @@ final class CsrfTest extends TestCase
         self::assertStringContainsString('Path=/', $this->fetchSetCookie($response, 'csrf-token'));
     }
 
-    public function testCookiePathFollowsBasePath(): void
-    {
-        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/myapp']));
-
-        $core = $this->httpCore([CsrfMiddleware::class]);
-        $core->setHandler(
-            static fn($r) => $r->getAttribute(CsrfMiddleware::ATTRIBUTE),
-        );
-
-        $response = $this->get($core, '/myapp/feature/123');
-        self::assertSame(200, $response->getStatusCode());
-
-        self::assertStringContainsString('Path=/myapp', $this->fetchSetCookie($response, 'csrf-token'));
-    }
-
-    public function testCookiePathConfigOverridesBasePath(): void
+    public function testCookiePathIsConfigurable(): void
     {
         $this->container->bind(
             CsrfConfig::class,
@@ -81,7 +66,6 @@ final class CsrfTest extends TestCase
                 ],
             ),
         );
-        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/myapp']));
 
         $core = $this->httpCore([CsrfMiddleware::class]);
         $core->setHandler(
@@ -246,7 +230,6 @@ final class CsrfTest extends TestCase
             ),
         );
 
-        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/']));
         $this->container->bind(TracerInterface::class, new NullTracer($this->container));
         $this->container->bind(
             ResponseFactoryInterface::class,

--- a/src/Csrf/tests/CsrfTest.php
+++ b/src/Csrf/tests/CsrfTest.php
@@ -40,6 +40,60 @@ final class CsrfTest extends TestCase
         self::assertSame($cookies['csrf-token'], (string) $response->getBody());
     }
 
+    public function testCookieHasDefaultPath(): void
+    {
+        $core = $this->httpCore([CsrfMiddleware::class]);
+        $core->setHandler(
+            static fn($r) => $r->getAttribute(CsrfMiddleware::ATTRIBUTE),
+        );
+
+        $response = $this->get($core, '/feature/123');
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertStringContainsString('Path=/', $this->fetchSetCookie($response, 'csrf-token'));
+    }
+
+    public function testCookiePathFollowsBasePath(): void
+    {
+        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/myapp']));
+
+        $core = $this->httpCore([CsrfMiddleware::class]);
+        $core->setHandler(
+            static fn($r) => $r->getAttribute(CsrfMiddleware::ATTRIBUTE),
+        );
+
+        $response = $this->get($core, '/myapp/feature/123');
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertStringContainsString('Path=/myapp', $this->fetchSetCookie($response, 'csrf-token'));
+    }
+
+    public function testCookiePathConfigOverridesBasePath(): void
+    {
+        $this->container->bind(
+            CsrfConfig::class,
+            new CsrfConfig(
+                [
+                    'cookie'   => 'csrf-token',
+                    'length'   => 16,
+                    'lifetime' => 86400,
+                    'path'     => '/admin',
+                ],
+            ),
+        );
+        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/myapp']));
+
+        $core = $this->httpCore([CsrfMiddleware::class]);
+        $core->setHandler(
+            static fn($r) => $r->getAttribute(CsrfMiddleware::ATTRIBUTE),
+        );
+
+        $response = $this->get($core, '/admin/dashboard');
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertStringContainsString('Path=/admin', $this->fetchSetCookie($response, 'csrf-token'));
+    }
+
     public function testLengthException(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -192,6 +246,7 @@ final class CsrfTest extends TestCase
             ),
         );
 
+        $this->container->bind(HttpConfig::class, new HttpConfig(['basePath' => '/']));
         $this->container->bind(TracerInterface::class, new NullTracer($this->container));
         $this->container->bind(
             ResponseFactoryInterface::class,
@@ -251,6 +306,17 @@ final class CsrfTest extends TestCase
         return $request
             ->withQueryParams($query)
             ->withCookieParams($cookies);
+    }
+
+    private function fetchSetCookie(ResponseInterface $response, string $name): string
+    {
+        foreach ($response->getHeader('Set-Cookie') as $headerLine) {
+            if (\str_starts_with($headerLine, $name . '=')) {
+                return $headerLine;
+            }
+        }
+
+        return '';
     }
 
     private function fetchCookies(ResponseInterface $response): array

--- a/src/Framework/Bootloader/Http/CsrfBootloader.php
+++ b/src/Framework/Bootloader/Http/CsrfBootloader.php
@@ -20,6 +20,7 @@ final class CsrfBootloader extends Bootloader
                 'lifetime' => 86400,
                 'secure'   => true,
                 'sameSite' => null,
+                'path'     => '/',
             ],
         );
     }

--- a/tests/Framework/Bootloader/Http/CsrfBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/CsrfBootloaderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Bootloader\Http;
+
+use Spiral\Csrf\Config\CsrfConfig;
+use Spiral\Tests\Framework\BaseTestCase;
+
+final class CsrfBootloaderTest extends BaseTestCase
+{
+    public function testConfig(): void
+    {
+        $this->assertConfigMatches(CsrfConfig::CONFIG, [
+            'cookie'   => 'csrf-token',
+            'length'   => 16,
+            'lifetime' => 86400,
+            'secure'   => true,
+            'sameSite' => null,
+            'path'     => '/',
+        ]);
+    }
+
+    public function testCookiePathDefault(): void
+    {
+        $config = $this->getContainer()->get(CsrfConfig::class);
+
+        self::assertSame('/', $config->getCookiePath());
+    }
+}


### PR DESCRIPTION
## What was changed

`CsrfMiddleware::tokenCookie()` hardcoded the cookie path to `null`, so the `Set-Cookie` header was emitted without a `Path=` attribute. Per [RFC 6265 §5.1.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4) the browser then scopes the cookie to the directory of the URL that set it, fragmenting `csrf-token` into multiple path-scoped copies. AJAX requests issued to a different path prefix than the page send no matching cookie, `CsrfMiddleware` mints a fresh token, and `CsrfFirewall` rejects the `X-CSRF-Token` header with `412 Bad CSRF Token`. This breaks the OWASP Double Submit Cookie pattern the middleware documents.

## How it is fixed

Add a `path` option to `CsrfConfig` (default `'/'`) and use it in `CsrfMiddleware::tokenCookie()` instead of the hardcoded `null`. `'/'` is the domain-wide scope the Double Submit Cookie pattern requires, so the token cookie is sent on every request regardless of the URL prefix.

Apps mounted under a sub-directory (or hosting several apps on one domain under different base paths) can narrow the scope via `app/config/csrf.php`:

```php
return [
    // ...
    'path' => '/my-app',
];
```

### Why not default to `HttpConfig::getBasePath()`

An earlier revision injected `HttpConfig` to mirror `SessionMiddleware`'s scoping. That was dropped because `spiral/csrf` is a standalone package that does **not** depend on `spiral/http` (it is `require-dev` only), so referencing `HttpConfig` from the middleware violates the package boundary. Moving the base-path lookup into `CsrfBootloader` was also rejected: reading `HttpConfig` during bootloader `init()` delivers the `http` config before other bootloaders can patch it (e.g. `addMiddleware()`), throwing `ConfigDeliveredException`. A static `'/'` default with an explicit `csrf.path` override keeps the package boundary clean and covers the sub-path case.

## Checklist

- Closes #1256
- Tested
    - [ ] Tested manually
    - [x] Unit tests added