### PR TITLE
Add StructArmed to QA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ phpcs.xml              export-ignore
 phpunit.xml            export-ignore
 psalm.xml              export-ignore
 rector.php             export-ignore
+structarmed.php        export-ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,51 @@ jobs:
           vendor/bin/psalm --no-cache --shepherd --stats --output-format=checkstyle --php-version=${{ matrix.php }}
           vendor/bin/rector --dry-run --clear-cache
 
+  architecture:
+    name: StructArmed
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2']
+        os: [ubuntu-latest]
+
+    steps:
+      # General Steps
+      - name: Set Git To Use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure environment
+        run: |
+          export COMPOSER_ROOT_VERSION=$(/usr/bin/jq --null-input --raw-output 'first(inputs["extra"]["branch-alias"])[]' composer.json)
+          echo COMPOSER_ROOT_VERSION=$COMPOSER_ROOT_VERSION >> $GITHUB_ENV
+
+      # Install PHP and Dependencies
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Validate Composer
+        run: composer validate
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--prefer-dist --no-audit"
+
+      - name: Install StructArmed
+        run: composer require --dev boundwize/structarmed:^0.12.0 --no-interaction --prefer-dist --no-audit
+
+      # Execution
+      - name: Run StructArmed
+        run: vendor/bin/structarmed analyse
+
   #
   # Execute unit tests on all valid PHP versions.
   #

--- a/structarmed.php
+++ b/structarmed.php
@@ -7,6 +7,8 @@ use Boundwize\StructArmed\Preset\Preset;
 
 return Architecture::define()
     ->skipPaths([
+        // per src/ has own autoload-dev which needs to be tested separately
+        // if needed
         'src/*/tests',
     ])
     ->withPreset(Preset::PSR4());

--- a/structarmed.php
+++ b/structarmed.php
@@ -7,8 +7,8 @@ use Boundwize\StructArmed\Preset\Preset;
 
 return Architecture::define()
     ->skipPaths([
-        // per src/ has own autoload-dev which needs to be tested separately
-        // if needed
+        // per src/ has own autoload-dev which needs to their tests directory need to be skipped
+        // or may require special handling for it
         'src/*/tests',
     ])
     ->withPreset(Preset::PSR4());

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->skipPaths([
+        'src/*/tests',
+    ])
+    ->withPreset(Preset::PSR4());

--- a/tests/Framework/Attribute/DispatcherScopeTest.php
+++ b/tests/Framework/Attribute/DispatcherScopeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\Attribute;
+namespace Spiral\Tests\Framework\Attribute;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Spiral\App\Dispatcher\DispatcherWithCustomEnum;

--- a/tests/Framework/Auth/Config/AuthConfigTest.php
+++ b/tests/Framework/Auth/Config/AuthConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Auth\Config;
+namespace Spiral\Tests\Framework\Auth\Config;
 
 use Spiral\Auth\Config\AuthConfig;
 use Spiral\Auth\TokenStorageInterface as SessionTokenStorageInterface;

--- a/tests/Framework/Auth/TokenStorageScopeTest.php
+++ b/tests/Framework/Auth/TokenStorageScopeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\Auth;
+namespace Spiral\Tests\Framework\Auth;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Auth\TokenInterface;

--- a/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
+++ b/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\AuthHttp\Middleware;
+namespace Spiral\Tests\Framework\AuthHttp\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Spiral\Auth\Middleware\AuthMiddleware;

--- a/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Attributes;
+namespace Spiral\Tests\Framework\Bootloader\Attributes;
 
 use Spiral\Attributes\Composite\SelectiveReader;
 use Spiral\Attributes\Internal\Instantiator\Facade;

--- a/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Attributes;
+namespace Spiral\Tests\Framework\Bootloader\Attributes;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Bootloader\Attributes\AttributesConfig;

--- a/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Attributes/AttributesWithoutAnnotationsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Attributes;
+namespace Spiral\Tests\Framework\Bootloader\Attributes;
 
 use Spiral\Attributes\AttributeReader;
 use Spiral\Attributes\Composite\SelectiveReader;

--- a/tests/Framework/Bootloader/Auth/AuthBootloaderTest.php
+++ b/tests/Framework/Bootloader/Auth/AuthBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Auth;
+namespace Spiral\Tests\Framework\Bootloader\Auth;
 
 use Spiral\Auth\ActorProviderInterface;
 use Spiral\Auth\AuthScope;

--- a/tests/Framework/Bootloader/Boot/ConfigurationBootloaderTest.php
+++ b/tests/Framework/Bootloader/Boot/ConfigurationBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Boot;
+namespace Spiral\Tests\Framework\Bootloader\Boot;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Config\ConfiguratorInterface;

--- a/tests/Framework/Bootloader/Boot/CoreBootloaderTest.php
+++ b/tests/Framework/Bootloader/Boot/CoreBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Boot;
+namespace Spiral\Tests\Framework\Bootloader\Boot;
 
 use Spiral\Boot\Memory;
 use Spiral\Boot\MemoryInterface;

--- a/tests/Framework/Bootloader/Broadcasting/BroadcastingBootloaderTest.php
+++ b/tests/Framework/Bootloader/Broadcasting/BroadcastingBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Broadcasting;
+namespace Spiral\Tests\Framework\Bootloader\Broadcasting;
 
 use Spiral\Broadcasting\Bootloader\BroadcastingBootloader;
 use Spiral\Broadcasting\BroadcastInterface;

--- a/tests/Framework/Bootloader/Broadcasting/WebsocketsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Broadcasting/WebsocketsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Broadcasting;
+namespace Spiral\Tests\Framework\Bootloader\Broadcasting;
 
 use Spiral\Broadcasting\Middleware\AuthorizationMiddleware;
 use Spiral\Tests\Framework\BaseTestCase;

--- a/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
+++ b/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Cache;
+namespace Spiral\Tests\Framework\Bootloader\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 use Spiral\Cache\Bootloader\CacheBootloader;

--- a/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
+++ b/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Console;
+namespace Spiral\Tests\Framework\Bootloader\Console;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;

--- a/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
+++ b/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Debug;
+namespace Spiral\Tests\Framework\Bootloader\Debug;
 
 use Spiral\Boot\Environment\AppEnvironment;
 use Spiral\Bootloader\DebugBootloader;

--- a/tests/Framework/Bootloader/Debug/ScopedDebugBootloaderTest.php
+++ b/tests/Framework/Bootloader/Debug/ScopedDebugBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Debug;
+namespace Spiral\Tests\Framework\Bootloader\Debug;
 
 use Spiral\Bootloader\DebugBootloader;
 use Spiral\Config\ConfigManager;

--- a/tests/Framework/Bootloader/Distribution/DistributionBootloaderTest.php
+++ b/tests/Framework/Bootloader/Distribution/DistributionBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Distribution;
+namespace Spiral\Tests\Framework\Bootloader\Distribution;
 
 use Mockery as m;
 use Spiral\Distribution\Config\DistributionConfig;

--- a/tests/Framework/Bootloader/DomainBootloaderTest.php
+++ b/tests/Framework/Bootloader/DomainBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader;
+namespace Spiral\Tests\Framework\Bootloader;
 
 use Spiral\App\Interceptor\One;
 use Spiral\App\Interceptor\Three;

--- a/tests/Framework/Bootloader/Events/EventsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Events/EventsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Events;
+namespace Spiral\Tests\Framework\Bootloader\Events;
 
 use Mockery as m;
 use Psr\Container\ContainerInterface;

--- a/tests/Framework/Bootloader/Exceptions/SnapshotsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Exceptions/SnapshotsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Exceptions;
+namespace Spiral\Tests\Framework\Bootloader\Exceptions;
 
 use Spiral\Snapshots\FileSnapshooter;
 use Spiral\Snapshots\FileSnapshot;

--- a/tests/Framework/Bootloader/Exceptions/StorageSnapshotsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Exceptions/StorageSnapshotsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Exceptions;
+namespace Spiral\Tests\Framework\Bootloader\Exceptions;
 
 use Spiral\Bootloader\StorageSnapshotsBootloader;
 use Spiral\Core\Container;

--- a/tests/Framework/Bootloader/Http/CookiesBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/CookiesBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Spiral\Bootloader\Http\CookiesBootloader;

--- a/tests/Framework/Bootloader/Http/CsrfBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/CsrfBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use Spiral\Csrf\Config\CsrfConfig;
 use Spiral\Tests\Framework\BaseTestCase;

--- a/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Spiral\Auth\ActorProviderInterface;

--- a/tests/Framework/Bootloader/Http/JsonPayloadsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/JsonPayloadsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use Spiral\Bootloader\Http\JsonPayloadConfig;
 use Spiral\Bootloader\Http\JsonPayloadsBootloader;

--- a/tests/Framework/Bootloader/Http/PaginationBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/PaginationBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use Spiral\Framework\Spiral;

--- a/tests/Framework/Bootloader/Http/SessionBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/SessionBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Http;
+namespace Spiral\Tests\Framework\Bootloader\Http;
 
 use Spiral\Framework\Spiral;
 use Spiral\Session\SessionFactory;

--- a/tests/Framework/Bootloader/Prototype/PrototypeBootloaderTest.php
+++ b/tests/Framework/Bootloader/Prototype/PrototypeBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Prototype;
+namespace Spiral\Tests\Framework\Bootloader\Prototype;
 
 use Spiral\App\SomeService\Client;
 use Spiral\App\SomeService\HttpClient;

--- a/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
+++ b/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Queue;
+namespace Spiral\Tests\Framework\Bootloader\Queue;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;

--- a/tests/Framework/Bootloader/Router/RouterBootloaderTest.php
+++ b/tests/Framework/Bootloader/Router/RouterBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Router;
+namespace Spiral\Tests\Framework\Bootloader\Router;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;

--- a/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
+++ b/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Scaffolder;
+namespace Spiral\Tests\Framework\Bootloader\Scaffolder;
 
 use Cocur\Slugify\Slugify;
 use Cocur\Slugify\SlugifyInterface;

--- a/tests/Framework/Bootloader/Security/EncrypterBootloaderTest.php
+++ b/tests/Framework/Bootloader/Security/EncrypterBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Security;
+namespace Spiral\Tests\Framework\Bootloader\Security;
 
 use Spiral\Encrypter\Config\EncrypterConfig;
 use Spiral\Encrypter\Encrypter;

--- a/tests/Framework/Bootloader/Security/FiltersBootloaderTest.php
+++ b/tests/Framework/Bootloader/Security/FiltersBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Security;
+namespace Spiral\Tests\Framework\Bootloader\Security;
 
 use Spiral\Bootloader\Security\FiltersBootloader;
 use Spiral\Config\ConfigManager;

--- a/tests/Framework/Bootloader/Security/GuardBootloaderTest.php
+++ b/tests/Framework/Bootloader/Security/GuardBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Security;
+namespace Spiral\Tests\Framework\Bootloader\Security;
 
 use Spiral\Domain\GuardPermissionsProvider;
 use Spiral\Domain\PermissionsProviderInterface;

--- a/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
+++ b/tests/Framework/Bootloader/SendIt/MailerBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\SendIt;
+namespace Spiral\Tests\Framework\Bootloader\SendIt;
 
 use Spiral\Mailer\MailerInterface;
 use Spiral\SendIt\Bootloader\MailerBootloader;

--- a/tests/Framework/Bootloader/Serializer/SerializerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Serializer/SerializerBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Serializer;
+namespace Spiral\Tests\Framework\Bootloader\Serializer;
 
 use Spiral\Serializer\Config\SerializerConfig;
 use Spiral\Serializer\Serializer\JsonSerializer;

--- a/tests/Framework/Bootloader/Storage/StorageBootloaderTest.php
+++ b/tests/Framework/Bootloader/Storage/StorageBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Storage;
+namespace Spiral\Tests\Framework\Bootloader\Storage;
 
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;

--- a/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
+++ b/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Telemetry;
+namespace Spiral\Tests\Framework\Bootloader\Telemetry;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Tokenizer;
+namespace Spiral\Tests\Framework\Bootloader\Tokenizer;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Config\LoaderInterface;

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerListenerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerListenerBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Tokenizer;
+namespace Spiral\Tests\Framework\Bootloader\Tokenizer;
 
 use Spiral\App\Tokenizer\TestInterface;
 use Spiral\Testing\Attribute\Env;

--- a/tests/Framework/Bootloader/Translation/I18nBootloaderTest.php
+++ b/tests/Framework/Bootloader/Translation/I18nBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Translation;
+namespace Spiral\Tests\Framework\Bootloader\Translation;
 
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\Environment\DebugMode;

--- a/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
+++ b/tests/Framework/Bootloader/Validation/ValidationBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Validation;
+namespace Spiral\Tests\Framework\Bootloader\Validation;
 
 use Psr\Container\NotFoundExceptionInterface;
 use Spiral\Config\ConfiguratorInterface;

--- a/tests/Framework/Bootloader/Views/ViewsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Views/ViewsBootloaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Bootloader\Views;
+namespace Spiral\Tests\Framework\Bootloader\Views;
 
 use Spiral\Config\ConfigManager;
 use Spiral\Tests\Framework\BaseTestCase;

--- a/tests/Framework/Console/CommandDescriptionTest.php
+++ b/tests/Framework/Console/CommandDescriptionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Console;
+namespace Spiral\Tests\Framework\Console;
 
 use Spiral\Tests\Framework\ConsoleTestCase;
 

--- a/tests/Framework/Console/Confirmation/ApplicationInProductionCommandTest.php
+++ b/tests/Framework/Console/Confirmation/ApplicationInProductionCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Console\Confirmation;
+namespace Spiral\Tests\Framework\Console\Confirmation;
 
 use Spiral\Framework\Spiral;
 use Spiral\Testing\Attribute\Env;

--- a/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
+++ b/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Console\Confirmation;
+namespace Spiral\Tests\Framework\Console\Confirmation;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/tests/Framework/Filter/InputScopeTest.php
+++ b/tests/Framework/Filter/InputScopeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Filter;
+namespace Spiral\Tests\Framework\Filter;
 
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Framework/Filter/JsonErrorsRendererTest.php
+++ b/tests/Framework/Filter/JsonErrorsRendererTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Filter;
+namespace Spiral\Tests\Framework\Filter;
 
 use Spiral\Filter\JsonErrorsRenderer;
 use Spiral\Http\ResponseWrapper;

--- a/tests/Framework/Filter/Model/FilterWithSettersTest.php
+++ b/tests/Framework/Filter/Model/FilterWithSettersTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Filter\Model;
+namespace Spiral\Tests\Framework\Filter\Model;
 
 use Spiral\App\Request\FilterWithSetters;
 use Spiral\App\Request\PostFilter;

--- a/tests/Framework/Filter/Model/MethodAttributeTest.php
+++ b/tests/Framework/Filter/Model/MethodAttributeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Filter\Model;
+namespace Spiral\Tests\Framework\Filter\Model;
 
 use Spiral\App\Request\TestRequest;
 use Spiral\Framework\Spiral;

--- a/tests/Framework/Filter/ValidationHandlerMiddlewareTest.php
+++ b/tests/Framework/Filter/ValidationHandlerMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Filter;
+namespace Spiral\Tests\Framework\Filter;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Framework/Framework/KernelTest.php
+++ b/tests/Framework/Framework/KernelTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Framework;
+namespace Spiral\Tests\Framework\Framework;
 
 use Spiral\App\TestApp;
 use Spiral\Tests\Framework\BaseTestCase;

--- a/tests/Framework/Tokenizer/Config/ConfigTest.php
+++ b/tests/Framework/Tokenizer/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Framework\Tokenizer\Config;
+namespace Spiral\Tests\Framework\Tokenizer\Config;
 
 use Spiral\Testing\Attribute\Env;
 use Spiral\Tests\Framework\BaseTestCase;


### PR DESCRIPTION
## What was changed

This PR adds StructArmed to github workflow static analysis for QA.

https://github.com/boundwize/structarmed

StructArmed is a configurable PHP architecture guard, that we can define layers and rules, then keep them enforced. 

For starter, this PR uses the PSR4 preset, and already found violations that fixed and included in this PR.

Since this repo support php 8.1 as well, this only add on github workflow on php 8.2 👍

On more practical use case of how set the config layer -> ruleset for more complex use, you can take a look on how cakephp and codeigniter4 uses it :)

- https://github.com/cakephp/cakephp/blob/5.next/structarmed.php
- https://github.com/codeigniter4/CodeIgniter4/blob/develop/structarmed.php

## Why?

This adds an automated architecture guard, and for starter, add psr4 preset for the starter only to give quick entrance.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually



