### PR TITLE
Update composer audit to run without dev dependencies and run composer cs:fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Execution
       - name: Audit dependencies
-        run: composer audit
+        run: composer audit --no-dev
 
   static-analysis:
     name: Psalm and Rector

--- a/src/Logger/tests/TraitTest.php
+++ b/src/Logger/tests/TraitTest.php
@@ -45,7 +45,7 @@ final class TraitTest extends TestCase
         $logsInterfaceLogger = new NullLogger();
         $logs = m::mock(LogsInterface::class);
         $logs->shouldReceive('getLogger')
-            ->with(static::class)
+            ->with(self::class)
             ->andReturn($logsInterfaceLogger);
 
         $container = new Container();

--- a/src/Pagination/tests/LimitsTraitTest.php
+++ b/src/Pagination/tests/LimitsTraitTest.php
@@ -21,16 +21,16 @@ final class LimitsTraitTest extends TestCase
 
     public function testLimit(): void
     {
-        self::assertEquals(static::DEFAULT_LIMIT, $this->trait->getLimit());
-        self::assertEquals($this->trait, $this->trait->limit(static::LIMIT));
-        self::assertEquals(static::LIMIT, $this->trait->getLimit());
+        self::assertEquals(self::DEFAULT_LIMIT, $this->trait->getLimit());
+        self::assertEquals($this->trait, $this->trait->limit(self::LIMIT));
+        self::assertEquals(self::LIMIT, $this->trait->getLimit());
     }
 
     public function testOffset(): void
     {
-        self::assertEquals(static::DEFAULT_OFFSET, $this->trait->getOffset());
-        self::assertEquals($this->trait, $this->trait->offset(static::OFFSET));
-        self::assertEquals(static::OFFSET, $this->trait->getOffset());
+        self::assertEquals(self::DEFAULT_OFFSET, $this->trait->getOffset());
+        self::assertEquals($this->trait, $this->trait->offset(self::OFFSET));
+        self::assertEquals(self::OFFSET, $this->trait->getOffset());
     }
 
     protected function setUp(): void

--- a/src/Security/tests/GuardTest.php
+++ b/src/Security/tests/GuardTest.php
@@ -39,13 +39,13 @@ final class GuardTest extends TestCase
         $rule = $this->createMock(RuleInterface::class);
         $rule->expects($this->once())
             ->method('allows')
-            ->with($this->actor, static::OPERATION, [])->willReturn(true);
+            ->with($this->actor, self::OPERATION, [])->willReturn(true);
 
         $this->permission->method('getRule')
             ->willReturn($rule);
 
         $guard = new Guard($this->permission, $this->actor, $this->roles);
-        self::assertTrue($guard->allows(static::OPERATION, static::CONTEXT));
+        self::assertTrue($guard->allows(self::OPERATION, self::CONTEXT));
     }
 
     public function testAllowsPermissionsHasNoRole(): void
@@ -53,7 +53,7 @@ final class GuardTest extends TestCase
         $this->permission->method('hasRole')->with($this->anything())->willReturn(false);
 
         $guard = new Guard($this->permission, $this->actor, $this->roles);
-        self::assertFalse($guard->allows(static::OPERATION, static::CONTEXT));
+        self::assertFalse($guard->allows(self::OPERATION, self::CONTEXT));
     }
 
     public function testAllowsNoActor(): void
@@ -61,7 +61,7 @@ final class GuardTest extends TestCase
         $guard = new Guard($this->permission, null, $this->roles);
 
         $this->expectException(GuardException::class);
-        $guard->allows(static::OPERATION, static::CONTEXT);
+        $guard->allows(self::OPERATION, self::CONTEXT);
     }
 
     public function testWithActor(): void

--- a/src/Security/tests/PermissionManagerTest.php
+++ b/src/Security/tests/PermissionManagerTest.php
@@ -29,11 +29,11 @@ final class PermissionManagerTest extends TestCase
     {
         $manager = new PermissionManager($this->rules);
 
-        self::assertFalse($manager->hasRole(static::ROLE));
-        self::assertEquals($manager, $manager->addRole(static::ROLE));
-        self::assertTrue($manager->hasRole(static::ROLE));
-        self::assertEquals($manager, $manager->removeRole(static::ROLE));
-        self::assertFalse($manager->hasRole(static::ROLE));
+        self::assertFalse($manager->hasRole(self::ROLE));
+        self::assertEquals($manager, $manager->addRole(self::ROLE));
+        self::assertTrue($manager->hasRole(self::ROLE));
+        self::assertEquals($manager, $manager->removeRole(self::ROLE));
+        self::assertFalse($manager->hasRole(self::ROLE));
 
         $manager->addRole('one');
         $manager->addRole('two');
@@ -45,8 +45,8 @@ final class PermissionManagerTest extends TestCase
         $manager = new PermissionManager($this->rules);
 
         $this->expectException(RoleException::class);
-        $manager->addRole(static::ROLE);
-        $manager->addRole(static::ROLE);
+        $manager->addRole(self::ROLE);
+        $manager->addRole(self::ROLE);
     }
 
     public function testRemoveRoleException(): void
@@ -54,7 +54,7 @@ final class PermissionManagerTest extends TestCase
         $manager = new PermissionManager($this->rules);
 
         $this->expectException(RoleException::class);
-        $manager->removeRole(static::ROLE);
+        $manager->removeRole(self::ROLE);
     }
 
     public function testAssociation(): void
@@ -78,18 +78,18 @@ final class PermissionManagerTest extends TestCase
             });
 
         $manager = new PermissionManager($this->rules);
-        $manager->addRole(static::ROLE);
+        $manager->addRole(self::ROLE);
 
         // test simple permission
-        self::assertEquals($manager, $manager->associate(static::ROLE, static::PERMISSION, AllowRule::class));
-        self::assertEquals($allowRule, $manager->getRule(static::ROLE, static::PERMISSION));
+        self::assertEquals($manager, $manager->associate(self::ROLE, self::PERMISSION, AllowRule::class));
+        self::assertEquals($allowRule, $manager->getRule(self::ROLE, self::PERMISSION));
 
         // test pattern permission
-        self::assertEquals($manager, $manager->associate(static::ROLE, static::PERMISSION . '.*', AllowRule::class));
-        self::assertEquals($allowRule, $manager->getRule(static::ROLE, static::PERMISSION . '.' . static::PERMISSION));
+        self::assertEquals($manager, $manager->associate(self::ROLE, self::PERMISSION . '.*', AllowRule::class));
+        self::assertEquals($allowRule, $manager->getRule(self::ROLE, self::PERMISSION . '.' . self::PERMISSION));
 
-        self::assertEquals($manager, $manager->deassociate(static::ROLE, static::PERMISSION));
-        self::assertEquals($forbidRule, $manager->getRule(static::ROLE, static::PERMISSION));
+        self::assertEquals($manager, $manager->deassociate(self::ROLE, self::PERMISSION));
+        self::assertEquals($forbidRule, $manager->getRule(self::ROLE, self::PERMISSION));
     }
 
     public function testGetRuleRoleException(): void
@@ -97,7 +97,7 @@ final class PermissionManagerTest extends TestCase
         $manager = new PermissionManager($this->rules);
 
         $this->expectException(RoleException::class);
-        $manager->getRule(static::ROLE, static::PERMISSION);
+        $manager->getRule(self::ROLE, self::PERMISSION);
     }
 
     public function testRulesForRoleException(): void
@@ -126,13 +126,13 @@ final class PermissionManagerTest extends TestCase
     public function testGetFallbackRule(): void
     {
         $manager = new PermissionManager($this->rules);
-        $manager->addRole(static::ROLE);
+        $manager->addRole(self::ROLE);
 
         $this->rules->method('get')
             ->with(ForbidRule::class)
             ->willReturn(new ForbidRule());
 
-        self::assertInstanceOf(ForbidRule::class, $manager->getRule(static::ROLE, static::PERMISSION));
+        self::assertInstanceOf(ForbidRule::class, $manager->getRule(self::ROLE, self::PERMISSION));
     }
 
     public function testAssociateRoleException(): void
@@ -140,7 +140,7 @@ final class PermissionManagerTest extends TestCase
         $manager = new PermissionManager($this->rules);
 
         $this->expectException(RoleException::class);
-        $manager->associate(static::ROLE, static::PERMISSION);
+        $manager->associate(self::ROLE, self::PERMISSION);
     }
 
     public function testAssociatePermissionException(): void
@@ -148,8 +148,8 @@ final class PermissionManagerTest extends TestCase
         $this->expectException(PermissionException::class);
 
         $manager = new PermissionManager($this->rules);
-        $manager->addRole(static::ROLE);
-        $manager->associate(static::ROLE, static::PERMISSION);
+        $manager->addRole(self::ROLE);
+        $manager->associate(self::ROLE, self::PERMISSION);
     }
 
     protected function setUp(): void

--- a/src/Security/tests/RuleManagerTest.php
+++ b/src/Security/tests/RuleManagerTest.php
@@ -91,7 +91,7 @@ final class RuleManagerTest extends TestCase
         $manager = new RuleManager($this->container);
 
         $this->expectException(RuleException::class);
-        $manager->get(static::RULE_NAME);
+        $manager->get(self::RULE_NAME);
     }
 
     public function testGetWithSomethingOtherThanRule(): void

--- a/src/Security/tests/RuleTest.php
+++ b/src/Security/tests/RuleTest.php
@@ -63,7 +63,7 @@ final class RuleTest extends TestCase
     public function testAllowsException(): void
     {
         $this->expectException(RuleException::class);
-        $this->rule->allows($this->actor, static::OPERATION, static::CONTEXT);
+        $this->rule->allows($this->actor, self::OPERATION, self::CONTEXT);
     }
 
     protected function setUp(): void

--- a/src/Security/tests/Rules/AllowRuleTest.php
+++ b/src/Security/tests/Rules/AllowRuleTest.php
@@ -26,6 +26,6 @@ final class AllowRuleTest extends TestCase
         /** @var ActorInterface $actor */
         $actor = $this->createMock(ActorInterface::class);
 
-        self::assertTrue($rule->allows($actor, static::OPERATION, static::CONTEXT));
+        self::assertTrue($rule->allows($actor, self::OPERATION, self::CONTEXT));
     }
 }

--- a/src/Security/tests/Rules/CallableRuleTest.php
+++ b/src/Security/tests/Rules/CallableRuleTest.php
@@ -26,13 +26,13 @@ final class CallableRuleTest extends TestCase
             ->getMock();
 
         $callable->method('__invoke')
-            ->with($actor, static::OPERATION, $context)
+            ->with($actor, self::OPERATION, $context)
             ->willReturn(true, false);
 
         /** @var RuleInterface $rule */
         $rule = new CallableRule($callable);
 
-        self::assertTrue($rule->allows($actor, static::OPERATION, $context));
-        self::assertFalse($rule->allows($actor, static::OPERATION, $context));
+        self::assertTrue($rule->allows($actor, self::OPERATION, $context));
+        self::assertFalse($rule->allows($actor, self::OPERATION, $context));
     }
 }

--- a/src/Security/tests/Rules/CompositeRuleTest.php
+++ b/src/Security/tests/Rules/CompositeRuleTest.php
@@ -40,7 +40,7 @@ final class CompositeRuleTest extends TestCase
 
         /** @var RuleInterface $rule */
         $rule = new $compositeRuleClass($repository);
-        self::assertEquals($expected, $rule->allows($this->actor, static::OPERATION, static::CONTEXT));
+        self::assertEquals($expected, $rule->allows($this->actor, self::OPERATION, self::CONTEXT));
     }
 
     protected function setUp(): void

--- a/src/Security/tests/Rules/ForbidRuleTest.php
+++ b/src/Security/tests/Rules/ForbidRuleTest.php
@@ -26,6 +26,6 @@ final class ForbidRuleTest extends TestCase
         /** @var ActorInterface $actor */
         $actor = $this->createMock(ActorInterface::class);
 
-        self::assertFalse($rule->allows($actor, static::OPERATION, static::CONTEXT));
+        self::assertFalse($rule->allows($actor, self::OPERATION, self::CONTEXT));
     }
 }

--- a/src/Security/tests/Traits/GuardedTraitTest.php
+++ b/src/Security/tests/Traits/GuardedTraitTest.php
@@ -55,7 +55,7 @@ final class GuardedTraitTest extends TestCase
     public function testAllows(): void
     {
         $this->guard->method('allows')
-            ->with(static::OPERATION, static::CONTEXT)
+            ->with(self::OPERATION, self::CONTEXT)
             ->willReturn(true)
         ;
 
@@ -65,19 +65,19 @@ final class GuardedTraitTest extends TestCase
         $container->bind(GuardInterface::class, $this->guard);
 
         ContainerScope::runScope($container, static function () use ($guarded): void {
-            self::assertTrue($guarded->allows(static::OPERATION, static::CONTEXT));
-            self::assertFalse($guarded->denies(static::OPERATION, static::CONTEXT));
+            self::assertTrue($guarded->allows(self::OPERATION, self::CONTEXT));
+            self::assertFalse($guarded->denies(self::OPERATION, self::CONTEXT));
         });
     }
 
     public function testResolvePermission(): void
     {
         $guarded = new Guarded();
-        self::assertSame(static::OPERATION, $guarded->resolvePermission(static::OPERATION));
+        self::assertSame(self::OPERATION, $guarded->resolvePermission(self::OPERATION));
 
         $guarded = new GuardedWithNamespace();
-        $resolvedPermission = GuardedWithNamespace::GUARD_NAMESPACE . '.' . static::OPERATION;
-        self::assertSame($resolvedPermission, $guarded->resolvePermission(static::OPERATION));
+        $resolvedPermission = GuardedWithNamespace::GUARD_NAMESPACE . '.' . self::OPERATION;
+        self::assertSame($resolvedPermission, $guarded->resolvePermission(self::OPERATION));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Change composer audit command to exclude dev dependencies.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Use of `--no-dev` for run composer audit and run cs fix.

<!-- Describe what has changed in this PR -->

## Why?

Phpunit is not used for production as dev dependency.

This PR try to make security audit green.

Also run cs fix per master notice due to class is final so static can be updated to self.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
