### PR TITLE
Enable CreateStubOverCreateMockArgRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -130,7 +130,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\PHPUnit\PHPUnit120\Rector\CallLike\CreateStubOverCreateMockArgRector::class,
         \Rector\Php55\Rector\ClassConstFetch\StaticToSelfOnFinalClassRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\StringCastAssertStringContainsStringRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector::class,

--- a/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
+++ b/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
@@ -41,7 +41,7 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
             })
             ->willReturnSelf();
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
 
         $registry = new TransportRegistry();
         $registry->setTransport('header', $transport = $this->createMock(HttpTransportInterface::class));
@@ -61,8 +61,8 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
 
         $middleware = new AuthTransportWithStorageMiddleware(
             'header',
-            $this->createMock(ScopeInterface::class),
-            $this->createMock(ActorProviderInterface::class),
+            $this->createStub(ScopeInterface::class),
+            $this->createStub(ActorProviderInterface::class),
             $storageProvider,
             $registry,
             storage: 'session',

--- a/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
+++ b/src/Bridge/Monolog/tests/Config/MonologConfigTest.php
@@ -38,7 +38,7 @@ final class MonologConfigTest extends TestCase
         $config = new MonologConfig([
             'handlers' => [
                 'foo' => [
-                    $this->createMock(HandlerInterface::class),
+                    $this->createStub(HandlerInterface::class),
                 ],
             ],
         ]);
@@ -53,7 +53,7 @@ final class MonologConfigTest extends TestCase
         $config = new MonologConfig([
             'processors' => [
                 'foo' => [
-                    $this->createMock(ProcessorInterface::class),
+                    $this->createStub(ProcessorInterface::class),
                 ],
             ],
         ]);

--- a/src/Bridge/Monolog/tests/RotateHandlerTest.php
+++ b/src/Bridge/Monolog/tests/RotateHandlerTest.php
@@ -62,7 +62,7 @@ final class RotateHandlerTest extends BaseTestCase
         $finalizer->shouldReceive('addFinalizer')->once();
 
         $this->container->bind(EnvironmentInterface::class, new Environment(['MONOLOG_FORMAT' => 'foo']));
-        $this->container->bind(ConfiguratorInterface::class, $this->createMock(ConfiguratorInterface::class));
+        $this->container->bind(ConfiguratorInterface::class, $this->createStub(ConfiguratorInterface::class));
         $this->container->get(StrategyBasedBootloadManager::class)->bootload([MonologBootloader::class]);
 
         $autowire = new Container\Autowire('log.rotate', [

--- a/src/Console/tests/PromptArgumentsTest.php
+++ b/src/Console/tests/PromptArgumentsTest.php
@@ -32,7 +32,7 @@ final class PromptArgumentsTest extends BaseTestCase
         $command->setDefinition(new InputDefinition([new InputArgument('command', InputArgument::REQUIRED)]));
 
 
-        $promptArguments->promptMissedArguments($command, $input, $this->createMock(OutputInterface::class));
+        $promptArguments->promptMissedArguments($command, $input, $this->createStub(OutputInterface::class));
     }
 
     public function testPromptArgumentWithDefaultQuestion(): void

--- a/src/Core/tests/InjectableTest.php
+++ b/src/Core/tests/InjectableTest.php
@@ -180,7 +180,7 @@ final class InjectableTest extends TestCase
                 // Context
                 null,
             )
-            ->willReturn($this->createMock($class));
+            ->willReturn($this->createStub($class));
 
         $container = new Container();
         $container->bind('injector', $mock);

--- a/src/Core/tests/ScopesTest.php
+++ b/src/Core/tests/ScopesTest.php
@@ -17,7 +17,7 @@ final class ScopesTest extends TestCase
 {
     public function testScope(): void
     {
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
         self::assertNull(ContainerScope::getContainer());
 
@@ -28,7 +28,7 @@ final class ScopesTest extends TestCase
 
     public function testScopeException(): void
     {
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->createStub(ContainerInterface::class);
 
         self::assertNull(ContainerScope::getContainer());
 

--- a/src/Filters/tests/Mapper/CasterRegistryTest.php
+++ b/src/Filters/tests/Mapper/CasterRegistryTest.php
@@ -16,7 +16,7 @@ final class CasterRegistryTest extends TestCase
         $registry = new CasterRegistry();
         self::assertCount(0, $registry->getCasters());
 
-        $setter = $this->createMock(CasterInterface::class);
+        $setter = $this->createStub(CasterInterface::class);
         $registry->register($setter);
         self::assertCount(1, $registry->getCasters());
         self::assertSame([$setter], $registry->getCasters());

--- a/src/Filters/tests/Mapper/DefaultCasterTest.php
+++ b/src/Filters/tests/Mapper/DefaultCasterTest.php
@@ -13,13 +13,13 @@ final class DefaultCasterTest extends TestCase
 {
     public function testSupports(): void
     {
-        self::assertTrue((new DefaultCaster())->supports($this->createMock(\ReflectionNamedType::class)));
+        self::assertTrue((new DefaultCaster())->supports($this->createStub(\ReflectionNamedType::class)));
     }
 
     public function testSetValue(): void
     {
         $setter = new DefaultCaster();
-        $filter = $this->createMock(AddressFilter::class);
+        $filter = $this->createStub(AddressFilter::class);
         $property = new \ReflectionProperty($filter, 'city');
 
         $setter->setValue($filter, $property, 'foo');
@@ -29,7 +29,7 @@ final class DefaultCasterTest extends TestCase
     public function testSetValueException(): void
     {
         $setter = new DefaultCaster();
-        $filter = $this->createMock(AddressFilter::class);
+        $filter = $this->createStub(AddressFilter::class);
         $property = new \ReflectionProperty($filter, 'city');
 
         $this->expectException(SetterException::class);

--- a/src/Filters/tests/Mapper/EnumCasterTest.php
+++ b/src/Filters/tests/Mapper/EnumCasterTest.php
@@ -30,7 +30,7 @@ final class EnumCasterTest extends TestCase
     public function testSetValue(): void
     {
         $setter = new EnumCaster();
-        $filter = $this->createMock(UserFilter::class);
+        $filter = $this->createStub(UserFilter::class);
         $property = new \ReflectionProperty($filter, 'status');
 
         $setter->setValue($filter, $property, 'active');
@@ -40,7 +40,7 @@ final class EnumCasterTest extends TestCase
     public function testSetValueException(): void
     {
         $setter = new EnumCaster();
-        $filter = $this->createMock(UserFilter::class);
+        $filter = $this->createStub(UserFilter::class);
         $property = new \ReflectionProperty($filter, 'status');
 
         $this->expectException(SetterException::class);

--- a/src/Filters/tests/Mapper/UuidCasterTest.php
+++ b/src/Filters/tests/Mapper/UuidCasterTest.php
@@ -30,7 +30,7 @@ final class UuidCasterTest extends TestCase
     public function testSetValue(): void
     {
         $setter = new UuidCaster();
-        $filter = $this->createMock(UserFilter::class);
+        $filter = $this->createStub(UserFilter::class);
         $property = new \ReflectionProperty($filter, 'groupUuid');
 
         $setter->setValue($filter, $property, '11111111-1111-1111-1111-111111111111');
@@ -40,7 +40,7 @@ final class UuidCasterTest extends TestCase
     public function testSetValueException(): void
     {
         $setter = new UuidCaster();
-        $filter = $this->createMock(UserFilter::class);
+        $filter = $this->createStub(UserFilter::class);
         $ref = new \ReflectionProperty($filter, 'friendUuid');
 
         $this->expectException(SetterException::class);

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -245,11 +245,11 @@ final class RetryPolicyInterceptorTest extends TestCase
         $this->core = $this->createMock(CoreInterface::class);
 
         $registry = new QueueRegistry(
-            $this->createMock(ContainerInterface::class),
-            $this->createMock(FactoryInterface::class),
-            $this->createMock(HandlerRegistryInterface::class),
+            $this->createStub(ContainerInterface::class),
+            $this->createStub(FactoryInterface::class),
+            $this->createStub(HandlerRegistryInterface::class),
         );
-        $registry->setHandler('foo', $this->createMock(HandlerInterface::class));
+        $registry->setHandler('foo', $this->createStub(HandlerInterface::class));
 
         $this->interceptor = new RetryPolicyInterceptor($this->reader, $registry);
     }

--- a/src/Queue/tests/JobHandlerLocatorListenerTest.php
+++ b/src/Queue/tests/JobHandlerLocatorListenerTest.php
@@ -18,12 +18,12 @@ final class JobHandlerLocatorListenerTest extends TestCase
 {
     public function testListen(): void
     {
-        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+        $handler = new class($this->createStub(InvokerInterface::class)) extends JobHandler {};
 
         $registry = new QueueRegistry(
             new Container(),
             new Container(),
-            $this->createMock(HandlerRegistryInterface::class),
+            $this->createStub(HandlerRegistryInterface::class),
         );
 
         $reader = $this->createMock(ReaderInterface::class);

--- a/src/Queue/tests/SerializerLocatorListenerTest.php
+++ b/src/Queue/tests/SerializerLocatorListenerTest.php
@@ -22,7 +22,7 @@ final class SerializerLocatorListenerTest extends TestCase
 {
     public function testListenWithJobTypeFromConfig(): void
     {
-        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+        $handler = new class($this->createStub(InvokerInterface::class)) extends JobHandler {};
 
         $container = new Container();
         $container->bind('test', new PhpSerializer());
@@ -31,7 +31,7 @@ final class SerializerLocatorListenerTest extends TestCase
         $registry = new QueueRegistry(
             $container,
             $container,
-            $this->createMock(HandlerRegistryInterface::class),
+            $this->createStub(HandlerRegistryInterface::class),
         );
 
         $reader = m::mock(ReaderInterface::class);
@@ -58,7 +58,7 @@ final class SerializerLocatorListenerTest extends TestCase
 
     public function testListenWithJobTypeFromAttribute(): void
     {
-        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+        $handler = new class($this->createStub(InvokerInterface::class)) extends JobHandler {};
 
         $container = new Container();
         $container->bind('test', new PhpSerializer());
@@ -67,7 +67,7 @@ final class SerializerLocatorListenerTest extends TestCase
         $registry = new QueueRegistry(
             $container,
             $container,
-            $this->createMock(HandlerRegistryInterface::class),
+            $this->createStub(HandlerRegistryInterface::class),
         );
 
         $reader = m::mock(ReaderInterface::class);
@@ -94,7 +94,7 @@ final class SerializerLocatorListenerTest extends TestCase
 
     public function testListenWithJobTypeFromClass(): void
     {
-        $handler = new class($this->createMock(InvokerInterface::class)) extends JobHandler {};
+        $handler = new class($this->createStub(InvokerInterface::class)) extends JobHandler {};
 
         $container = new Container();
         $container->bind('test', new PhpSerializer());
@@ -103,7 +103,7 @@ final class SerializerLocatorListenerTest extends TestCase
         $registry = new QueueRegistry(
             $container,
             $container,
-            $this->createMock(HandlerRegistryInterface::class),
+            $this->createStub(HandlerRegistryInterface::class),
         );
 
         $reader = m::mock(ReaderInterface::class);

--- a/src/Router/tests/Loader/PhpFileLoaderTest.php
+++ b/src/Router/tests/Loader/PhpFileLoaderTest.php
@@ -44,8 +44,8 @@ final class PhpFileLoaderTest extends TestCase
     protected function setUp(): void
     {
         $this->container = new Container();
-        $this->container->bind(LoaderInterface::class, $this->createMock(LoaderInterface::class));
-        $this->container->bind(RouterInterface::class, $this->createMock(RouterInterface::class));
-        $this->container->bind(UriFactoryInterface::class, $this->createMock(UriFactoryInterface::class));
+        $this->container->bind(LoaderInterface::class, $this->createStub(LoaderInterface::class));
+        $this->container->bind(RouterInterface::class, $this->createStub(RouterInterface::class));
+        $this->container->bind(UriFactoryInterface::class, $this->createStub(UriFactoryInterface::class));
     }
 }

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -40,7 +40,7 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
     public function testCreatesFromArrayWithPipeline(): void
     {
         $newPipeline = new Pipeline(
-            scope: $this->createMock(ScopeInterface::class),
+            scope: $this->createStub(ScopeInterface::class),
         );
 
         self::assertSame($newPipeline, $this->pipeline->createWithMiddleware([$newPipeline]));
@@ -56,7 +56,7 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
             ->once()
             ->with(Pipeline::class)
             ->andReturn($p = new Pipeline(
-                $this->createMock(ScopeInterface::class),
+                $this->createStub(ScopeInterface::class),
                 tracer: new NullTracer($container),
             ));
 
@@ -99,7 +99,7 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 
         $p
             ->withHandler($requestHandler)
-            ->handle($this->createMock(ServerRequestInterface::class));
+            ->handle($this->createStub(ServerRequestInterface::class));
     }
 
     #[DataProvider('invalidTypeDataProvider')]

--- a/src/Router/tests/RouteGroupTest.php
+++ b/src/Router/tests/RouteGroupTest.php
@@ -161,7 +161,7 @@ final class RouteGroupTest extends BaseTestCase
         parent::setUp();
 
         $this->container = new Container();
-        $this->container->bind(LoaderInterface::class, $this->createMock(LoaderInterface::class));
+        $this->container->bind(LoaderInterface::class, $this->createStub(LoaderInterface::class));
         $this->container->bind(UriFactoryInterface::class, Psr17Factory::class);
     }
 

--- a/src/Router/tests/RouterTest.php
+++ b/src/Router/tests/RouterTest.php
@@ -83,9 +83,9 @@ final class RouterTest extends BaseTestCase
     public function testImportWithHost(): void
     {
         $groupRegistry = $this->getContainer()->get(GroupRegistry::class);
-        $router = $this->makeRouter('https://host.com', $this->createMock(EventDispatcherInterface::class));
+        $router = $this->makeRouter('https://host.com', $this->createStub(EventDispatcherInterface::class));
 
-        $configurator = new RoutingConfigurator(new RouteCollection(), $this->createMock(LoaderInterface::class));
+        $configurator = new RoutingConfigurator(new RouteCollection(), $this->createStub(LoaderInterface::class));
         $configurator->add('foo', '//<host>/register')->callable(static fn() => null);
 
         $router->import($configurator);
@@ -105,9 +105,9 @@ final class RouterTest extends BaseTestCase
             ->setNamePrefix('console.')
             ->setPrefix('/console');
 
-        $router = $this->makeRouter(dispatcher: $this->createMock(EventDispatcherInterface::class));
+        $router = $this->makeRouter(dispatcher: $this->createStub(EventDispatcherInterface::class));
 
-        $configurator = new RoutingConfigurator(new RouteCollection(), $this->createMock(LoaderInterface::class));
+        $configurator = new RoutingConfigurator(new RouteCollection(), $this->createStub(LoaderInterface::class));
         $configurator
             ->add('some-path', 'some/path')
             ->group('console:user')

--- a/src/Security/tests/Rules/AllowRuleTest.php
+++ b/src/Security/tests/Rules/AllowRuleTest.php
@@ -24,7 +24,7 @@ final class AllowRuleTest extends TestCase
         /** @var RuleInterface $rule */
         $rule = new AllowRule();
         /** @var ActorInterface $actor */
-        $actor = $this->createMock(ActorInterface::class);
+        $actor = $this->createStub(ActorInterface::class);
 
         self::assertTrue($rule->allows($actor, self::OPERATION, self::CONTEXT));
     }

--- a/src/Security/tests/Rules/CallableRuleTest.php
+++ b/src/Security/tests/Rules/CallableRuleTest.php
@@ -17,7 +17,7 @@ final class CallableRuleTest extends TestCase
     public function testAllow(): void
     {
         /** @var ActorInterface $actor */
-        $actor = $this->createMock(ActorInterface::class);
+        $actor = $this->createStub(ActorInterface::class);
         $context = [];
 
         /** @var \PHPUnit\Framework\MockObject\MockObject|callable $callable */

--- a/src/Security/tests/Rules/ForbidRuleTest.php
+++ b/src/Security/tests/Rules/ForbidRuleTest.php
@@ -24,7 +24,7 @@ final class ForbidRuleTest extends TestCase
         /** @var RuleInterface $rule */
         $rule = new ForbidRule();
         /** @var ActorInterface $actor */
-        $actor = $this->createMock(ActorInterface::class);
+        $actor = $this->createStub(ActorInterface::class);
 
         self::assertFalse($rule->allows($actor, self::OPERATION, self::CONTEXT));
     }

--- a/src/Serializer/tests/Bootloader/SerializerBootloaderTest.php
+++ b/src/Serializer/tests/Bootloader/SerializerBootloaderTest.php
@@ -81,7 +81,7 @@ final class SerializerBootloaderTest extends TestCase
             'default' => 'json',
             'serializers' => $serializers,
         ]));
-        $bootloader = new SerializerBootloader($this->createMock(ConfiguratorInterface::class), $this->container, $this->container);
+        $bootloader = new SerializerBootloader($this->createStub(ConfiguratorInterface::class), $this->container, $this->container);
 
         $this->container->bindSingleton(SerializerRegistryInterface::class, [$bootloader, 'initSerializerRegistry']);
         $this->container->bindSingleton(SerializerManager::class, [$bootloader, 'initSerializerManager']);

--- a/src/Storage/tests/BucketFactoryTest.php
+++ b/src/Storage/tests/BucketFactoryTest.php
@@ -15,7 +15,7 @@ final class BucketFactoryTest extends TestCase
         $factory = new BucketFactory();
 
         $bucket = $factory->createFromAdapter(
-            $this->createMock(FilesystemAdapter::class),
+            $this->createStub(FilesystemAdapter::class),
             $name = 'foo',
         );
 
@@ -28,7 +28,7 @@ final class BucketFactoryTest extends TestCase
         $factory = new BucketFactory();
 
         $bucket = $factory->createFromAdapter(
-            $this->createMock(FilesystemAdapter::class),
+            $this->createStub(FilesystemAdapter::class),
             $name = 'foo',
             $resolver = $this->createMock(UriResolverInterface::class),
         );

--- a/tests/Framework/Auth/TokenStorageScopeTest.php
+++ b/tests/Framework/Auth/TokenStorageScopeTest.php
@@ -50,7 +50,7 @@ final class TokenStorageScopeTest extends TestCase
 
     public function testDelete(): void
     {
-        $token = $this->createMock(TokenInterface::class);
+        $token = $this->createStub(TokenInterface::class);
 
         $storage = $this->createMock(TokenStorageInterface::class);
         $storage

--- a/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
+++ b/tests/Framework/AuthHttp/Middleware/AuthMiddlewareTest.php
@@ -18,7 +18,7 @@ final class AuthMiddlewareTest extends HttpTestCase
     #[TestScope(Spiral::Http)]
     public function testTokenStorageInterfaceShouldBeBound(): void
     {
-        $storage = $this->createMock(TokenStorageInterface::class);
+        $storage = $this->createStub(TokenStorageInterface::class);
         $this->getContainer()->bind(
             AuthMiddleware::class,
             new Autowire(AuthMiddleware::class, ['tokenStorage' => $storage]),

--- a/tests/Framework/Bootloader/Broadcasting/BroadcastingBootloaderTest.php
+++ b/tests/Framework/Bootloader/Broadcasting/BroadcastingBootloaderTest.php
@@ -48,7 +48,7 @@ final class BroadcastingBootloaderTest extends BaseTestCase
 
     public function testRegisterDriverAlias(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(BroadcastConfig::CONFIG, ['driverAliases' => []]);
 
         $bootloader = new BroadcastingBootloader($configs);

--- a/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
+++ b/tests/Framework/Bootloader/Cache/CacheBootloaderTest.php
@@ -54,7 +54,7 @@ final class CacheBootloaderTest extends BaseTestCase
 
     public function testRegisterTypeAlias(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(CacheConfig::CONFIG, ['typeAliases' => []]);
 
         $bootloader = new CacheBootloader($configs);

--- a/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
+++ b/tests/Framework/Bootloader/Console/ConsoleBootloaderTest.php
@@ -35,7 +35,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testAddInterceptor(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['interceptors' => []]);
 
         $bootloader = new ConsoleBootloader($configs);
@@ -49,7 +49,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testAddCommand(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['commands' => []]);
 
         $bootloader = new ConsoleBootloader($configs);
@@ -65,7 +65,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testAddConfigureSequence(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
 
         $bootloader = new ConsoleBootloader($configs);
@@ -82,7 +82,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testAddUpdateSequence(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
 
         $bootloader = new ConsoleBootloader($configs);
@@ -99,7 +99,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testAddCustomSequence(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
 
         $bootloader = new ConsoleBootloader($configs);
@@ -116,7 +116,7 @@ final class ConsoleBootloaderTest extends BaseTestCase
 
     public function testSequencesIsNotDuplicated(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ConsoleConfig::CONFIG, ['sequences' => []]);
 
         $bootloader = new ConsoleBootloader($configs);

--- a/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
+++ b/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
@@ -30,10 +30,10 @@ final class DebugBootloaderTest extends BaseTestCase
 
     public function testAddCollector(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(DebugConfig::CONFIG, ['collectors' => []]);
 
-        $collector = $this->createMock(StateCollectorInterface::class);
+        $collector = $this->createStub(StateCollectorInterface::class);
         $autowire = new Autowire('foo');
 
         $bootloader = new DebugBootloader($this->getContainer(), $configs);
@@ -46,7 +46,7 @@ final class DebugBootloaderTest extends BaseTestCase
 
     public function testAddTag(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(DebugConfig::CONFIG, ['tags' => []]);
 
         $class = new class {
@@ -94,7 +94,7 @@ final class DebugBootloaderTest extends BaseTestCase
 
     public function testResolveTagCallableDeps(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(DebugConfig::CONFIG, ['tags' => []]);
 
         $bootloader = new DebugBootloader($this->getContainer(), $configs);

--- a/tests/Framework/Bootloader/Debug/ScopedDebugBootloaderTest.php
+++ b/tests/Framework/Bootloader/Debug/ScopedDebugBootloaderTest.php
@@ -22,7 +22,7 @@ final class ScopedDebugBootloaderTest extends TestCase
 
     public function testAddCollectorFromOtherScope(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(DebugConfig::CONFIG, ['collectors' => []]);
 
         $bootloader = $this->getContainer()->get(DebugBootloader::class);

--- a/tests/Framework/Bootloader/Events/EventsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Events/EventsBootloaderTest.php
@@ -131,7 +131,7 @@ final class EventsBootloaderTest extends BaseTestCase
         $kernel = $this->getContainer()->get(AbstractKernel::class);
 
         $finalizer = m::mock(FinalizerInterface::class, EventDispatcherAwareInterface::class);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $finalizer->shouldReceive('setEventDispatcher')->once()->with($dispatcher);
 
         $this->bootBootloader(
@@ -148,7 +148,7 @@ final class EventsBootloaderTest extends BaseTestCase
         $kernel = $this->getContainer()->get(AbstractKernel::class);
 
         $finalizer = m::mock(FinalizerInterface::class);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $finalizer->shouldReceive('setEventDispatcher')->never();
 
         $this->bootBootloader(
@@ -161,10 +161,10 @@ final class EventsBootloaderTest extends BaseTestCase
 
     public function testAddInterceptor(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(EventsConfig::CONFIG, ['interceptors' => []]);
 
-        $interceptor = $this->createMock(CoreInterceptorInterface::class);
+        $interceptor = $this->createStub(CoreInterceptorInterface::class);
         $autowire = new Container\Autowire('foo');
 
         $bootloader = new EventsBootloader($configs);
@@ -182,7 +182,7 @@ final class EventsBootloaderTest extends BaseTestCase
         $bootloader = $this->getContainer()->get(EventsBootloader::class);
         $kernel = $this->getContainer()->get(AbstractKernel::class);
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
         $this->getContainer()->bindSingleton(EventDispatcherInterface::class, static fn(): EventDispatcherInterface => $dispatcher);
 
         $finalizer = m::mock(FinalizerInterface::class, EventDispatcherAwareInterface::class);

--- a/tests/Framework/Bootloader/Http/CookiesBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/CookiesBootloaderTest.php
@@ -63,7 +63,7 @@ final class CookiesBootloaderTest extends BaseTestCase
 
     public function testWhitelistCookie(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(CookiesConfig::CONFIG, ['excluded' => []]);
 
         $bootloader = new CookiesBootloader($configs, $this->getContainer());

--- a/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpAuthBootloaderTest.php
@@ -48,7 +48,7 @@ final class HttpAuthBootloaderTest extends BaseTestCase
         $request = $this->createMock(ServerRequestInterface::class);
         $request
             ->method('getAttribute')
-            ->willReturn(new AuthContext($this->createMock(ActorProviderInterface::class)));
+            ->willReturn(new AuthContext($this->createStub(ActorProviderInterface::class)));
 
         $currentRequest = new CurrentRequest();
         $currentRequest->set($request);
@@ -76,7 +76,7 @@ final class HttpAuthBootloaderTest extends BaseTestCase
 
     public function testCorrectDefaultTransports(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
 
         $bootloader = new HttpAuthBootloader($configs);
         $bootloader->init(
@@ -141,7 +141,7 @@ final class HttpAuthBootloaderTest extends BaseTestCase
 
     public function testAddTokenStorage(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(AuthConfig::CONFIG, ['storages' => []]);
 
         $bootloader = new HttpAuthBootloader($configs, $this->getContainer());
@@ -152,7 +152,7 @@ final class HttpAuthBootloaderTest extends BaseTestCase
 
     public function testAddTransport(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(AuthConfig::CONFIG, ['transports' => []]);
 
         $bootloader = new HttpAuthBootloader($configs, $this->getContainer());

--- a/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/HttpBootloaderTest.php
@@ -44,7 +44,7 @@ final class HttpBootloaderTest extends BaseTestCase
 
     public function testAddInputBag(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(HttpConfig::CONFIG, ['inputBags' => []]);
 
         $bootloader = new HttpBootloader($configs, new Container());
@@ -58,7 +58,7 @@ final class HttpBootloaderTest extends BaseTestCase
     #[DataProvider('middlewaresDataProvider')]
     public function testAddMiddleware(mixed $middleware): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(HttpConfig::CONFIG, ['middleware' => []]);
 
         $bootloader = new HttpBootloader($configs, new Container());

--- a/tests/Framework/Bootloader/Http/JsonPayloadsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Http/JsonPayloadsBootloaderTest.php
@@ -27,7 +27,7 @@ final class JsonPayloadsBootloaderTest extends BaseTestCase
 
     public function testAddContentType(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(JsonPayloadConfig::CONFIG, ['contentTypes' => []]);
 
         $bootloader = new JsonPayloadsBootloader($configs);

--- a/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
+++ b/tests/Framework/Bootloader/Queue/QueueBootloaderTest.php
@@ -92,10 +92,10 @@ final class QueueBootloaderTest extends BaseTestCase
 
     public function testAddConsumeInterceptor(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(QueueConfig::CONFIG, ['interceptors' => ['consume' => []]]);
 
-        $interceptor = new ErrorHandlerInterceptor($this->createMock(FailedJobHandlerInterface::class));
+        $interceptor = new ErrorHandlerInterceptor($this->createStub(FailedJobHandlerInterface::class));
         $autowire = new Autowire(ErrorHandlerInterceptor::class);
 
         $bootloader = new QueueBootloader($configs);
@@ -110,10 +110,10 @@ final class QueueBootloaderTest extends BaseTestCase
 
     public function testAddPushInterceptor(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(QueueConfig::CONFIG, ['interceptors' => ['push' => []]]);
 
-        $interceptor = new ErrorHandlerInterceptor($this->createMock(FailedJobHandlerInterface::class));
+        $interceptor = new ErrorHandlerInterceptor($this->createStub(FailedJobHandlerInterface::class));
         $autowire = new Autowire(ErrorHandlerInterceptor::class);
 
         $bootloader = new QueueBootloader($configs);
@@ -128,7 +128,7 @@ final class QueueBootloaderTest extends BaseTestCase
 
     public function testRegisterDriverAlias(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(QueueConfig::CONFIG, ['driverAliases' => []]);
 
         $bootloader = new QueueBootloader($configs);

--- a/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
+++ b/tests/Framework/Bootloader/Scaffolder/ScaffolderBootloaderTest.php
@@ -24,10 +24,10 @@ final class ScaffolderBootloaderTest extends BaseTestCase
 
     public function testAddDeclaration(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(ScaffolderConfig::CONFIG, ['defaults' => ['declarations' => []]]);
 
-        $bootloader = new ScaffolderBootloader($configs, $this->createMock(KernelInterface::class));
+        $bootloader = new ScaffolderBootloader($configs, $this->createStub(KernelInterface::class));
         $bootloader->addDeclaration('foo', ['bar' => 'baz']);
 
         self::assertSame(['foo' => ['bar' => 'baz']], $configs->getConfig(ScaffolderConfig::CONFIG)['defaults']['declarations']);

--- a/tests/Framework/Bootloader/Security/FiltersBootloaderTest.php
+++ b/tests/Framework/Bootloader/Security/FiltersBootloaderTest.php
@@ -49,7 +49,7 @@ final class FiltersBootloaderTest extends BaseTestCase
 
     public function testAddInterceptor(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(FiltersConfig::CONFIG, ['interceptors' => []]);
 
         $container = $this->getContainer();

--- a/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
+++ b/tests/Framework/Bootloader/Telemetry/TelemetryBootloaderTest.php
@@ -57,7 +57,7 @@ final class TelemetryBootloaderTest extends BaseTestCase
 
     public function testRegisterTracer(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(TelemetryConfig::CONFIG, ['drivers' => []]);
 
         $bootloader = new TelemetryBootloader($configs);

--- a/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
+++ b/tests/Framework/Bootloader/Tokenizer/TokenizerBootloaderTest.php
@@ -74,7 +74,7 @@ final class TokenizerBootloaderTest extends BaseTestCase
 
     public function testAddDirectory(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(TokenizerConfig::CONFIG, ['directories' => []]);
 
         $bootloader = new TokenizerBootloader($configs);
@@ -85,7 +85,7 @@ final class TokenizerBootloaderTest extends BaseTestCase
 
     public function testAddScopedDirectoryWithNonExistScope(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(TokenizerConfig::CONFIG, ['scopes' => ['bar' => ['directories' => ['baz']]]]);
 
         $bootloader = new TokenizerBootloader($configs);
@@ -96,7 +96,7 @@ final class TokenizerBootloaderTest extends BaseTestCase
 
     public function testAddScopedDirectory(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(
             TokenizerConfig::CONFIG,
             ['scopes' => ['foo' => ['exclude' => ['baz'], 'directories' => ['baz']]]],
@@ -110,7 +110,7 @@ final class TokenizerBootloaderTest extends BaseTestCase
 
     public function testExcludeScopedDirectoryWithNonExistScope(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(TokenizerConfig::CONFIG, ['scopes' => []]);
 
         $bootloader = new TokenizerBootloader($configs);
@@ -121,7 +121,7 @@ final class TokenizerBootloaderTest extends BaseTestCase
 
     public function testExcludeScopedDirectory(): void
     {
-        $configs = new ConfigManager($this->createMock(LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(LoaderInterface::class));
         $configs->setDefaults(
             TokenizerConfig::CONFIG,
             ['scopes' => ['foo' => ['exclude' => ['baz'], 'directories' => ['baz']]]],

--- a/tests/Framework/Bootloader/Views/ViewsBootloaderTest.php
+++ b/tests/Framework/Bootloader/Views/ViewsBootloaderTest.php
@@ -41,7 +41,7 @@ final class ViewsBootloaderTest extends BaseTestCase
 
     public function testAddDirectoryWithNonExistNamespace(): void
     {
-        $configs = new ConfigManager($this->createMock(\Spiral\Config\LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(\Spiral\Config\LoaderInterface::class));
         $configs->setDefaults(ViewsConfig::CONFIG, ['namespaces' => []]);
 
         $bootloader = new ViewsBootloader($configs);
@@ -52,7 +52,7 @@ final class ViewsBootloaderTest extends BaseTestCase
 
     public function testAddDirectory(): void
     {
-        $configs = new ConfigManager($this->createMock(\Spiral\Config\LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(\Spiral\Config\LoaderInterface::class));
         $configs->setDefaults(ViewsConfig::CONFIG, ['namespaces' => ['foo' => ['baz']]]);
 
         $bootloader = new ViewsBootloader($configs);
@@ -63,7 +63,7 @@ final class ViewsBootloaderTest extends BaseTestCase
 
     public function testAddEngine(): void
     {
-        $configs = new ConfigManager($this->createMock(\Spiral\Config\LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(\Spiral\Config\LoaderInterface::class));
         $configs->setDefaults(ViewsConfig::CONFIG, ['engines' => []]);
 
         $bootloader = new ViewsBootloader($configs);
@@ -75,7 +75,7 @@ final class ViewsBootloaderTest extends BaseTestCase
 
     public function testAddCacheDependency(): void
     {
-        $configs = new ConfigManager($this->createMock(\Spiral\Config\LoaderInterface::class));
+        $configs = new ConfigManager($this->createStub(\Spiral\Config\LoaderInterface::class));
         $configs->setDefaults(ViewsConfig::CONFIG, ['dependencies' => []]);
 
         $bootloader = new ViewsBootloader($configs);

--- a/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
+++ b/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
@@ -26,8 +26,8 @@ final class ApplicationInProductionTest extends TestCase
     {
         $confirmation = new ApplicationInProduction(
             $env,
-            $this->createMock(InputInterface::class),
-            $this->createMock(OutputInterface::class),
+            $this->createStub(InputInterface::class),
+            $this->createStub(OutputInterface::class),
         );
 
         self::assertTrue($confirmation->confirmToProceed());
@@ -38,7 +38,7 @@ final class ApplicationInProductionTest extends TestCase
         $confirmation = new ApplicationInProduction(
             AppEnvironment::Production,
             $input = $this->createMock(InputInterface::class),
-            $this->createMock(OutputInterface::class),
+            $this->createStub(OutputInterface::class),
         );
 
         $input->expects($this->once())->method('hasOption')->willReturn(true);

--- a/tests/Framework/Debug/HttpCollectorTest.php
+++ b/tests/Framework/Debug/HttpCollectorTest.php
@@ -15,8 +15,8 @@ final class HttpCollectorTest extends TestCase
     {
         $collector = new HttpCollector();
         $collector->process(
-            $this->createMock(ServerRequestInterface::class),
-            $this->createMock(RequestHandlerInterface::class),
+            $this->createStub(ServerRequestInterface::class),
+            $this->createStub(RequestHandlerInterface::class),
         );
         $collector->reset();
 

--- a/tests/Framework/KernelTest.php
+++ b/tests/Framework/KernelTest.php
@@ -102,7 +102,7 @@ final class KernelTest extends BaseTestCase
 
     public function testCustomBootloaderRegistry(): void
     {
-        $registry = $this->createMock(BootloaderRegistryInterface::class);
+        $registry = $this->createStub(BootloaderRegistryInterface::class);
         $container = new Container();
         $container->bindSingleton(BootloaderRegistryInterface::class, $registry);
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Use of createStub() when possible. 

<!-- Describe what has changed in this PR -->

## Why?

Use createStub() over createMock() when used as argument or array value and does not add any mock requirements.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Unit tests added
