### PR TITLE
Enable StaticToSelfOnFinalClassRector and StringCastAssertStringContainsStringRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -130,8 +130,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\Php55\Rector\ClassConstFetch\StaticToSelfOnFinalClassRector::class,
-        \Rector\PHPUnit\CodeQuality\Rector\MethodCall\StringCastAssertStringContainsStringRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector::class,
         \Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector::class,

--- a/src/Bridge/Stempler/tests/EngineTest.php
+++ b/src/Bridge/Stempler/tests/EngineTest.php
@@ -50,7 +50,7 @@ final class EngineTest extends BaseTestCase
             $t = $e->getUserTrace()[0];
 
             self::assertSame(2, $t['line']);
-            self::assertStringContainsString('echo.dark.php', $t['file']);
+            self::assertStringContainsString('echo.dark.php', (string) $t['file']);
         }
     }
 
@@ -66,10 +66,10 @@ final class EngineTest extends BaseTestCase
             self::assertCount(2, $t);
 
             self::assertSame(2, $t[0]['line']);
-            self::assertStringContainsString('echo.dark.php', $t[0]['file']);
+            self::assertStringContainsString('echo.dark.php', (string) $t[0]['file']);
 
             self::assertSame(3, $t[1]['line']);
-            self::assertStringContainsString('echo-in.dark.php', $t[1]['file']);
+            self::assertStringContainsString('echo-in.dark.php', (string) $t[1]['file']);
         }
     }
 

--- a/src/Console/tests/ConfigureTest.php
+++ b/src/Console/tests/ConfigureTest.php
@@ -81,9 +81,9 @@ final class ConfigureTest extends BaseTestCase
         $output = $core->run('configure', ['--break' => true]);
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringContainsString('Aborting.', $result);
-        self::assertStringNotContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringContainsString('Aborting.', (string) $result);
+        self::assertStringNotContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(1, $output->getCode());
     }
 
@@ -97,9 +97,9 @@ final class ConfigureTest extends BaseTestCase
         $output = $core->run('configure', ['--ignore' => true, '--break' => true]);
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringNotContainsString('Aborting.', $result);
-        self::assertStringContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringNotContainsString('Aborting.', (string) $result);
+        self::assertStringContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(0, $output->getCode());
     }
 
@@ -114,9 +114,9 @@ final class ConfigureTest extends BaseTestCase
         $output = $core->run('configure');
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringNotContainsString('Aborting.', $result);
-        self::assertStringContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringNotContainsString('Aborting.', (string) $result);
+        self::assertStringContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(1, $output->getCode());
     }
 

--- a/src/Console/tests/HelpersTest.php
+++ b/src/Console/tests/HelpersTest.php
@@ -31,23 +31,23 @@ final class HelpersTest extends BaseTestCase
 
     public function testSprintf(): void
     {
-        self::assertStringContainsString('hello world', $this->core->run('helper', ['helper' => 'sprintf'])->getOutput()->fetch());
+        self::assertStringContainsString('hello world', (string) $this->core->run('helper', ['helper' => 'sprintf'])->getOutput()->fetch());
     }
 
     public function testWriteln(): void
     {
-        self::assertStringContainsString("\n", $this->core->run('helper', ['helper' => 'writeln'])->getOutput()->fetch());
+        self::assertStringContainsString("\n", (string) $this->core->run('helper', ['helper' => 'writeln'])->getOutput()->fetch());
     }
 
     public function testTable(): void
     {
-        self::assertStringContainsString('id', $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
+        self::assertStringContainsString('id', (string) $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
 
-        self::assertStringContainsString('value', $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
+        self::assertStringContainsString('value', (string) $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
 
-        self::assertStringContainsString('1', $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
+        self::assertStringContainsString('1', (string) $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
 
-        self::assertStringContainsString('true', $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
+        self::assertStringContainsString('true', (string) $this->core->run('helper', ['helper' => 'table'])->getOutput()->fetch());
     }
 
     protected function setUp(): void

--- a/src/Console/tests/UpdateTest.php
+++ b/src/Console/tests/UpdateTest.php
@@ -78,9 +78,9 @@ text;
         $output = $core->run('update', ['--break' => true]);
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringContainsString('Aborting.', $result);
-        self::assertStringNotContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringContainsString('Aborting.', (string) $result);
+        self::assertStringNotContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(1, $output->getCode());
     }
 
@@ -94,9 +94,9 @@ text;
         $output = $core->run('update', ['--ignore' => true, '--break' => true]);
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringNotContainsString('Aborting.', $result);
-        self::assertStringContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringNotContainsString('Aborting.', (string) $result);
+        self::assertStringContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(0, $output->getCode());
     }
 
@@ -111,9 +111,9 @@ text;
         $output = $core->run('update');
         $result = $output->getOutput()->fetch();
 
-        self::assertStringContainsString('Unhandled failed command error at', $result);
-        self::assertStringNotContainsString('Aborting.', $result);
-        self::assertStringContainsString('Unhandled another failed command error at', $result);
+        self::assertStringContainsString('Unhandled failed command error at', (string) $result);
+        self::assertStringNotContainsString('Aborting.', (string) $result);
+        self::assertStringContainsString('Unhandled another failed command error at', (string) $result);
         self::assertSame(1, $output->getCode());
     }
 

--- a/src/Exceptions/tests/ExceptionHandlerTest.php
+++ b/src/Exceptions/tests/ExceptionHandlerTest.php
@@ -47,7 +47,7 @@ final class ExceptionHandlerTest extends TestCase
         $handler->setOutput(STDERR);
 
         \fseek($output, 0);
-        self::assertStringContainsString('Test message', \fread($output, 10000));
+        self::assertStringContainsString('Test message', (string) \fread($output, 10000));
     }
 
     public function testDefaultErrorRenderer(): void

--- a/src/Prototype/tests/Commands/InjectCommandTest.php
+++ b/src/Prototype/tests/Commands/InjectCommandTest.php
@@ -32,7 +32,7 @@ final class InjectCommandTest extends AbstractCommandsTestCase
         $reflection = new \ReflectionClass($target);
         $filename = $reflection->getFileName();
         $source = file_get_contents($filename);
-        self::assertStringContainsString('use PrototypeTrait;', $source);
+        self::assertStringContainsString('use PrototypeTrait;', (string) $source);
 
         try {
             $this->app->bindApp();
@@ -41,7 +41,7 @@ final class InjectCommandTest extends AbstractCommandsTestCase
             $out = new BufferedOutput();
             $this->app->get(Console::class)->run('prototype:inject', $inp, $out);
 
-            self::assertStringNotContainsString('use PrototypeTrait;', file_get_contents($filename));
+            self::assertStringNotContainsString('use PrototypeTrait;', (string) file_get_contents($filename));
         } finally {
             file_put_contents($filename, $source);
         }

--- a/src/Scaffolder/tests/Command/BootloaderTest.php
+++ b/src/Scaffolder/tests/Command/BootloaderTest.php
@@ -28,7 +28,7 @@ final class BootloaderTest extends AbstractCommandTestCase
         $content = $this->files()->read($reflection->getFileName());
 
         self::assertStringContainsString('strict_types=1', $content);
-        self::assertStringContainsString('Sample Bootloader', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Bootloader', (string) $reflection->getDocComment());
         self::assertStringContainsString('{project-name}', $content);
         self::assertStringContainsString('@author {author-name}', $content);
         self::assertTrue($reflection->hasMethod('boot'));

--- a/src/Scaffolder/tests/Command/ConfigTest.php
+++ b/src/Scaffolder/tests/Command/ConfigTest.php
@@ -30,7 +30,7 @@ final class ConfigTest extends AbstractCommandTestCase
         self::assertStringContainsString('strict_types=1', $content);
         self::assertStringContainsString('{project-name}', $content);
         self::assertStringContainsString('@author {author-name}', $content);
-        self::assertStringContainsString('Sample Config', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Config', (string) $reflection->getDocComment());
 
         self::assertTrue($reflection->isFinal());
         self::assertTrue($reflection->hasConstant('CONFIG'));

--- a/src/Scaffolder/tests/Command/ControllerTest.php
+++ b/src/Scaffolder/tests/Command/ControllerTest.php
@@ -30,7 +30,7 @@ final class ControllerTest extends AbstractCommandTestCase
         self::assertStringContainsString('strict_types=1', $content);
         self::assertStringContainsString('{project-name}', $content);
         self::assertStringContainsString('@author {author-name}', $content);
-        self::assertStringContainsString('Sample Controller', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Controller', (string) $reflection->getDocComment());
         self::assertTrue($reflection->hasMethod('index'));
         self::assertTrue($reflection->hasMethod('save'));
 

--- a/src/Scaffolder/tests/Command/InfoCommandTest.php
+++ b/src/Scaffolder/tests/Command/InfoCommandTest.php
@@ -24,7 +24,7 @@ final class InfoCommandTest extends AbstractCommandTestCase
         ];
 
         foreach ($strings as $string) {
-            self::assertStringContainsString($string, $result);
+            self::assertStringContainsString($string, (string) $result);
         }
     }
 }

--- a/src/Scaffolder/tests/Command/JobHandlerTest.php
+++ b/src/Scaffolder/tests/Command/JobHandlerTest.php
@@ -29,7 +29,7 @@ final class JobHandlerTest extends AbstractCommandTestCase
         self::assertStringContainsString('{project-name}', $content);
         self::assertStringContainsString('@author {author-name}', $content);
         self::assertStringContainsString('function invoke(string $id, mixed $payload, array $headers)', $content);
-        self::assertStringContainsString('Sample Job Handler', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Job Handler', (string) $reflection->getDocComment());
         self::assertTrue($reflection->hasMethod('invoke'));
     }
 

--- a/src/Scaffolder/tests/Command/MiddlewareTest.php
+++ b/src/Scaffolder/tests/Command/MiddlewareTest.php
@@ -28,7 +28,7 @@ final class MiddlewareTest extends AbstractCommandTestCase
         self::assertStringContainsString('strict_types=1', $content);
         self::assertStringContainsString('{project-name}', $content);
         self::assertStringContainsString('@author {author-name}', $content);
-        self::assertStringContainsString('Sample Middleware', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Middleware', (string) $reflection->getDocComment());
         self::assertTrue($reflection->hasMethod('process'));
     }
 

--- a/src/Scaffolder/tests/Command/NamespacedNameTest.php
+++ b/src/Scaffolder/tests/Command/NamespacedNameTest.php
@@ -27,7 +27,7 @@ final class NamespacedNameTest extends AbstractCommandTestCase
         $reflection = new \ReflectionClass(self::CLASS_NAME);
 
         self::assertStringContainsString('strict_types=1', $this->files()->read($reflection->getFileName()));
-        self::assertStringContainsString('Sample Controller', $reflection->getDocComment());
+        self::assertStringContainsString('Sample Controller', (string) $reflection->getDocComment());
         self::assertTrue($reflection->hasMethod('index'));
         self::assertTrue($reflection->hasMethod('save'));
     }

--- a/src/Snapshots/tests/SnapshotTest.php
+++ b/src/Snapshots/tests/SnapshotTest.php
@@ -23,10 +23,10 @@ final class SnapshotTest extends TestCase
         self::assertStringContainsString("14", $s->getMessage());
 
         $description = $s->describe();
-        self::assertStringContainsString("Error", $description['error']);
-        self::assertStringContainsString("message", $description['error']);
-        self::assertStringContainsString(__FILE__, $description['error']);
-        self::assertStringContainsString("14", $description['error']);
+        self::assertStringContainsString("Error", (string) $description['error']);
+        self::assertStringContainsString("message", (string) $description['error']);
+        self::assertStringContainsString(__FILE__, (string) $description['error']);
+        self::assertStringContainsString("14", (string) $description['error']);
 
         self::assertSame(__FILE__, $description['location']['file']);
         self::assertSame(14, $description['location']['line']);

--- a/tests/Framework/Command/Encrypter/KeyCommandTest.php
+++ b/tests/Framework/Command/Encrypter/KeyCommandTest.php
@@ -57,10 +57,10 @@ final class KeyCommandTest extends ConsoleTestCase
 
         $out = $out->getOutput()->fetch();
 
-        self::assertStringContainsString('key has been updated', $out);
+        self::assertStringContainsString('key has been updated', (string) $out);
 
         $body = \file_get_contents(__DIR__ . '/.env');
-        self::assertStringContainsString($body, $out);
+        self::assertStringContainsString($body, (string) $out);
 
         \unlink(__DIR__ . '/.env');
     }

--- a/tests/Framework/Views/RenderTest.php
+++ b/tests/Framework/Views/RenderTest.php
@@ -41,9 +41,9 @@ final class RenderTest extends BaseTestCase
             ->get(ViewsInterface::class)
             ->render('stempler:globalVariables', ['replaced' => 'replaced-bar']);
 
-        self::assertStringContainsString('bar', $out);
-        self::assertStringContainsString('global-body', $out);
-        self::assertStringContainsString('replaced-bar', $out);
-        self::assertStringNotContainsString('replaced-foo', $out);
+        self::assertStringContainsString('bar', (string) $out);
+        self::assertStringContainsString('global-body', (string) $out);
+        self::assertStringContainsString('replaced-bar', (string) $out);
+        self::assertStringNotContainsString('replaced-foo', (string) $out);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Enable 2 rules: 

- StaticToSelfOnFinalClassRector
- StringCastAssertStringContainsStringRector

The applied rule in this PR is `StringCastAssertStringContainsStringRector` one.

<!-- Describe what has changed in this PR -->

## Why?

To ensure cast 2nd argument in assertStringContainsString() to a string if not yet (is mixed).

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
