### PR TITLE
Enable PreferPHPUnitSelfCallRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -130,7 +130,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\StmtsAwareInterface\DeclareStrictTypesTestsRector::class,
         \Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector::class,
         \Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector::class,

--- a/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
+++ b/src/AuthHttp/tests/AuthTransportWithStorageMiddlewareTest.php
@@ -23,15 +23,15 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
     {
         $storageProvider = $this->createMock(TokenStorageProviderInterface::class);
         $storageProvider
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getStorage')
             ->with('session')
             ->willReturn($tokenStorage = $this->createMock(TokenStorageInterface::class));
 
-        $matcher = $this->exactly(2);
+        $matcher = self::exactly(2);
         $request = $this->createMock(ServerRequestInterface::class);
         $request
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('withAttribute')
             ->willReturnCallback(static function (string $key, string $value) use ($matcher, $tokenStorage): void {
                 match ($matcher->numberOfInvocations()) {
@@ -46,18 +46,18 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
         $registry = new TransportRegistry();
         $registry->setTransport('header', $transport = $this->createMock(HttpTransportInterface::class));
 
-        $transport->expects($this->once())->method('fetchToken')->with($request)->willReturn('fooToken');
-        $transport->expects($this->once())->method('commitToken')->with($request, $response, '123', null)
+        $transport->expects(self::once())->method('fetchToken')->with($request)->willReturn('fooToken');
+        $transport->expects(self::once())->method('commitToken')->with($request, $response, '123', null)
             ->willReturn($response);
 
         $tokenStorage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('load')
             ->with('fooToken')
             ->willReturn($token = $this->createMock(TokenInterface::class));
 
-        $token->expects($this->once())->method('getID')->willReturn('123');
-        $token->expects($this->once())->method('getExpiresAt')->willReturn(null);
+        $token->expects(self::once())->method('getID')->willReturn('123');
+        $token->expects(self::once())->method('getExpiresAt')->willReturn(null);
 
         $middleware = new AuthTransportWithStorageMiddleware(
             'header',
@@ -69,7 +69,7 @@ final class AuthTransportWithStorageMiddlewareTest extends BaseTestCase
         );
 
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects($this->once())->method('handle')->with($request)->willReturn($response);
+        $handler->expects(self::once())->method('handle')->with($request)->willReturn($response);
 
         self::assertSame($response, $middleware->process($request, $handler));
     }

--- a/src/AuthHttp/tests/Middleware/AuthTransportMiddlewareTest.php
+++ b/src/AuthHttp/tests/Middleware/AuthTransportMiddlewareTest.php
@@ -48,15 +48,15 @@ final class AuthTransportMiddlewareTest extends BaseTestCase
         $auth = $this->getPrivateProperty('authMiddleware', $middleware->resolve($this->container));
 
         $authContext = $this->createMock(AuthContextInterface::class);
-        $authContext->expects($this->once())->method('getTransport')->willReturn(null);
-        $authContext->expects($this->once())->method('isClosed')->willReturn(false);
-        $authContext->expects($this->exactly(3))->method('getToken')->willReturn(new Token('1', []));
+        $authContext->expects(self::once())->method('getTransport')->willReturn(null);
+        $authContext->expects(self::once())->method('isClosed')->willReturn(false);
+        $authContext->expects(self::exactly(3))->method('getToken')->willReturn(new Token('1', []));
 
         $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())->method('withAddedHeader')->willReturn($response);
+        $response->expects(self::once())->method('withAddedHeader')->willReturn($response);
 
         $request = $this->createMock(ServerRequestInterface::class);
-        $request->expects($this->once())->method('hasHeader')->willReturn(false);
+        $request->expects(self::once())->method('hasHeader')->willReturn(false);
 
         (new \ReflectionMethod($auth, 'closeContext'))->invoke($auth, $request, $response, $authContext);
     }

--- a/src/Cache/tests/CacheRepositoryTest.php
+++ b/src/Cache/tests/CacheRepositoryTest.php
@@ -269,7 +269,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with($expectedKey)
             ->willReturn(null);
@@ -284,7 +284,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('set')
             ->with($expectedKey, 'foo')
             ->willReturn(true);
@@ -299,7 +299,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with($expectedKey)
             ->willReturn(true);
@@ -314,7 +314,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getMultiple')
             ->with([$expectedKey], null)
             ->willReturn([]);
@@ -329,7 +329,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('setMultiple')
             ->with([$expectedKey => 'foo'])
             ->willReturn(true);
@@ -344,7 +344,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('deleteMultiple')
             ->with([$expectedKey])
             ->willReturn(true);
@@ -359,7 +359,7 @@ final class CacheRepositoryTest extends TestCase
     {
         $storage = $this->createMock(CacheInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('has')
             ->with($expectedKey)
             ->willReturn(true);

--- a/src/Console/tests/PromptArgumentsTest.php
+++ b/src/Console/tests/PromptArgumentsTest.php
@@ -21,10 +21,10 @@ final class PromptArgumentsTest extends BaseTestCase
     {
         $input = $this->createMock(InputInterface::class);
         $input
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('getArgument');
         $input
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('setArgument');
 
         $promptArguments = new PromptArguments();

--- a/src/Core/tests/InjectableTest.php
+++ b/src/Core/tests/InjectableTest.php
@@ -170,7 +170,7 @@ final class InjectableTest extends TestCase
     public function testInjectableInheritance(string $class): void
     {
         $mock = $this->createMock(Container\InjectorInterface::class);
-        $mock->expects($this->once())
+        $mock->expects(self::once())
             ->method('createInjection')
             ->with(
                 // Class

--- a/src/Exceptions/tests/ExceptionHandlerTest.php
+++ b/src/Exceptions/tests/ExceptionHandlerTest.php
@@ -114,7 +114,7 @@ final class ExceptionHandlerTest extends TestCase
     public function testNonReportableExceptions(\Throwable $exception): void
     {
         $reporter = $this->createMock(ExceptionReporterInterface::class);
-        $reporter->expects($this->never())->method('report');
+        $reporter->expects(self::never())->method('report');
 
         $handler = $this->makeEmptyErrorHandler();
         $handler->addReporter($reporter);

--- a/src/Http/tests/HttpTest.php
+++ b/src/Http/tests/HttpTest.php
@@ -267,7 +267,7 @@ final class HttpTest extends TestCase
 
         $tracer = $this->createMock(TracerInterface::class);
         $tracer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('trace')
             ->with(
                 'GET http://example.org/path',
@@ -293,13 +293,13 @@ final class HttpTest extends TestCase
                 },
             );
         $tracer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getContext')
             ->willReturn([]);
 
         $tracerFactory = $this->createMock(TracerFactoryInterface::class);
         $tracerFactory
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('make')
             ->willReturn($tracer);
 

--- a/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
@@ -41,27 +41,27 @@ final class ErrorHandlerMiddlewareTest extends TestCase
     public function testHandleExceptionWithDebugFalse(\Throwable $e, int $code): void
     {
         $this->handler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('handle')
             ->with($this->request)
             ->willThrowException($e);
 
         $this->exceptionHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('report')
             ->with($e);
 
         $this->logger
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('error');
 
         $this->renderer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('renderException')
             ->with($this->request, $code, $e);
 
         $this->exceptionHandler
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('getRenderer');
 
         $middleware = new ErrorHandlerMiddleware(
@@ -81,32 +81,32 @@ final class ErrorHandlerMiddlewareTest extends TestCase
     {
         $renderer = $this->createMock(ExceptionRendererInterface::class);
         $renderer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with($e, Verbosity::DEBUG);
 
         $this->handler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('handle')
             ->with($this->request)
             ->willThrowException($e);
 
         $this->exceptionHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('report')
             ->with($e);
 
         $this->exceptionHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRenderer')
             ->willReturn($renderer);
 
         $this->logger
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->renderer
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('renderException');
 
         $middleware = new ErrorHandlerMiddleware(
@@ -128,32 +128,32 @@ final class ErrorHandlerMiddlewareTest extends TestCase
     {
         $renderer = $this->createMock(ExceptionRendererInterface::class);
         $renderer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with($e, Verbosity::VERBOSE);
 
         $this->handler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('handle')
             ->with($this->request)
             ->willThrowException($e);
 
         $this->exceptionHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('report')
             ->with($e);
 
         $this->exceptionHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getRenderer')
             ->willReturn($renderer);
 
         $this->logger
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('error');
 
         $this->renderer
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('renderException');
 
         $middleware = new ErrorHandlerMiddleware(

--- a/src/Prototype/tests/Commands/DumpCommandTest.php
+++ b/src/Prototype/tests/Commands/DumpCommandTest.php
@@ -25,7 +25,7 @@ final class DumpCommandTest extends AbstractCommandsTestCase
     {
         $files = $this->createMock(FilesInterface::class);
         $files
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('write')
             ->with(static::callback(fn (): bool => true), static::callback($this->validateTrait(...)));
 

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -34,10 +34,10 @@ final class RetryPolicyInterceptorTest extends TestCase
 
     public function testWithoutException(): void
     {
-        $this->reader->expects($this->never())->method('firstClassMetadata');
+        $this->reader->expects(self::never())->method('firstClassMetadata');
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with('foo', 'bar', [])
             ->willReturn('result');
@@ -48,10 +48,10 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithoutRetryPolicy(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(null);
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(null);
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', [])
             ->willThrowException(new \Exception('Something went wrong'));
@@ -64,10 +64,10 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testNotRetryableException(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', [])
             ->willThrowException(new \Exception('Something went wrong'));
@@ -80,10 +80,10 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithDefaultRetryPolicy(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(new RetryPolicy());
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', [])
             ->willThrowException(new TestRetryException());
@@ -99,10 +99,10 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithoutRetryPolicyAttribute(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(null);
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(null);
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', [])
             ->willThrowException(new TestRetryException(
@@ -120,12 +120,12 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithRetryPolicyInAttribute(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(
             new RetryPolicy(maxAttempts: 3, delay: 4, multiplier: 2),
         );
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', ['headers' => ['attempts' => ['1']]])
             ->willThrowException(new TestRetryException());
@@ -146,12 +146,12 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithRetryPolicyInException(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(
             new RetryPolicy(maxAttempts: 30, delay: 400, multiplier: 25),
         );
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', ['headers' => ['attempts' => ['1']]])
             ->willThrowException(new TestRetryException(
@@ -174,12 +174,12 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithCustomRetryPolicyInException(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(
             new RetryPolicy(maxAttempts: 30, delay: 400, multiplier: 25),
         );
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', ['headers' => ['attempts' => ['1']]])
             ->willThrowException(new TestRetryException(
@@ -212,12 +212,12 @@ final class RetryPolicyInterceptorTest extends TestCase
     #[DataProvider('jobNameDataProvider')]
     public function testWithRetryPolicyInExceptionInsideJobException(string $name): void
     {
-        $this->reader->expects($this->once())->method('firstClassMetadata')->willReturn(
+        $this->reader->expects(self::once())->method('firstClassMetadata')->willReturn(
             new RetryPolicy(maxAttempts: 30, delay: 400, multiplier: 25),
         );
 
         $this->core
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('callAction')
             ->with($name, 'bar', ['headers' => ['attempts' => ['1']]])
             ->willThrowException(new JobException(

--- a/src/Queue/tests/JobHandlerLocatorListenerTest.php
+++ b/src/Queue/tests/JobHandlerLocatorListenerTest.php
@@ -28,7 +28,7 @@ final class JobHandlerLocatorListenerTest extends TestCase
 
         $reader = $this->createMock(ReaderInterface::class);
         $reader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('firstClassMetadata')
             ->willReturn(new Attribute('test'));
 

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -67,7 +67,7 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
             ->andReturn($middleware5 = $this->createMock(MiddlewareInterface::class));
 
         $this->container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with('foo')
             ->willReturn($middleware4 = $this->createMock(MiddlewareInterface::class));
@@ -81,19 +81,19 @@ final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 
         $handle = static fn(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface => $handler->handle($request);
 
-        $middleware1->expects($this->once())->method('process')->willReturnCallback($handle);
-        $middleware2->expects($this->once())->method('process')->willReturnCallback($handle);
-        $middleware4->expects($this->once())->method('process')->willReturnCallback($handle);
-        $middleware5->expects($this->once())->method('process')->willReturnCallback($handle);
+        $middleware1->expects(self::once())->method('process')->willReturnCallback($handle);
+        $middleware2->expects(self::once())->method('process')->willReturnCallback($handle);
+        $middleware4->expects(self::once())->method('process')->willReturnCallback($handle);
+        $middleware5->expects(self::once())->method('process')->willReturnCallback($handle);
 
         $response = $this->createMock(ResponseInterface::class);
         $response
-            ->expects($this->exactly(4))->method('getHeaderLine')->with('Content-Length')->willReturn('test');
-        $response->expects($this->exactly(8))->method('getStatusCode')->willReturn(200);
+            ->expects(self::exactly(4))->method('getHeaderLine')->with('Content-Length')->willReturn('test');
+        $response->expects(self::exactly(8))->method('getStatusCode')->willReturn(200);
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
         $requestHandler
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('handle')
             ->willReturn($response);
 

--- a/src/Security/tests/GuardTest.php
+++ b/src/Security/tests/GuardTest.php
@@ -37,7 +37,7 @@ final class GuardTest extends TestCase
             });
 
         $rule = $this->createMock(RuleInterface::class);
-        $rule->expects($this->once())
+        $rule->expects(self::once())
             ->method('allows')
             ->with($this->actor, self::OPERATION, [])->willReturn(true);
 

--- a/src/Security/tests/RuleTest.php
+++ b/src/Security/tests/RuleTest.php
@@ -46,13 +46,13 @@ final class RuleTest extends TestCase
 
         $method = new \ReflectionMethod($this->rule, 'check');
         $this->resolver
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('resolveArguments')
             ->with($method, $parameters)
             ->willReturn([$parameters]);
 
         $this->rule
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('check')
             ->with($parameters)
             ->willReturn($allowed);

--- a/src/Snapshots/tests/StorageSnapshotTest.php
+++ b/src/Snapshots/tests/StorageSnapshotTest.php
@@ -23,13 +23,13 @@ final class StorageSnapshotTest extends TestCase
     {
         $this->renderer = $this->createMock(ExceptionRendererInterface::class);
         $this->renderer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->willReturn('foo');
 
         $this->file = $this->createMock(FileInterface::class);
         $this->file
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('write')
             ->with('foo');
 
@@ -37,7 +37,7 @@ final class StorageSnapshotTest extends TestCase
 
         $this->storage = $this->createMock(StorageInterface::class);
         $this->storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('bucket')
             ->willReturn($this->bucket);
     }
@@ -45,7 +45,7 @@ final class StorageSnapshotTest extends TestCase
     public function testCreate(): void
     {
         $this->bucket
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->with($this->callback(static fn (string $filename): bool => \str_contains($filename, 'Error.txt')))
             ->willReturn($this->file);
@@ -64,7 +64,7 @@ final class StorageSnapshotTest extends TestCase
     public function testCreateWithDirectory(): void
     {
         $this->bucket
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->with($this->callback(static fn (string $filename): bool => \str_starts_with($filename, 'foo/bar')))
             ->willReturn($this->file);

--- a/src/Telemetry/tests/LogTracerFactoryTest.php
+++ b/src/Telemetry/tests/LogTracerFactoryTest.php
@@ -18,7 +18,7 @@ final class LogTracerFactoryTest extends TestCase
     {
         $logs = $this->createMock(LogsInterface::class);
 
-        $logs->expects($this->once())
+        $logs->expects(self::once())
             ->method('getLogger')
             ->with('some-channel')
             ->willReturn($logger = $this->createMock(LoggerInterface::class));
@@ -31,7 +31,7 @@ final class LogTracerFactoryTest extends TestCase
         );
 
         $clock->method('now');
-        $logger->expects($this->once())->method('debug');
+        $logger->expects(self::once())->method('debug');
 
         self::assertInstanceOf(LogTracer::class, $tracer = $factory->make());
 

--- a/src/Tokenizer/tests/AbstractLocatorTest.php
+++ b/src/Tokenizer/tests/AbstractLocatorTest.php
@@ -25,7 +25,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'availableReflections');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('warning')->with(
+        $logger->expects(self::once())->method('warning')->with(
             $this->stringContains(' has includes and excluded from analysis')
         );
         $class->setLogger($logger);
@@ -39,7 +39,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'availableReflections');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->never())->method('warning');
+        $logger->expects(self::never())->method('warning');
         $class->setLogger($logger);
 
         \iterator_to_array($ref->invoke($class));
@@ -51,7 +51,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'classReflection');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->with(
+        $logger->expects(self::once())->method('error')->with(
             $this->stringContains("Class 'foo' can not be loaded")
         );
         $class->setLogger($logger);
@@ -68,7 +68,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'classReflection');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->never())->method('error');
+        $logger->expects(self::never())->method('error');
         $class->setLogger($logger);
 
         try {
@@ -83,7 +83,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'enumReflection');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->with(
+        $logger->expects(self::once())->method('error')->with(
             $this->stringContains("Enum 'foo' can not be loaded")
         );
         $class->setLogger($logger);
@@ -100,7 +100,7 @@ final class AbstractLocatorTest extends \PHPUnit\Framework\TestCase
         $ref = new \ReflectionMethod($class, 'enumReflection');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->never())->method('error');
+        $logger->expects(self::never())->method('error');
         $class->setLogger($logger);
 
         try {

--- a/tests/Framework/Auth/TokenStorageScopeTest.php
+++ b/tests/Framework/Auth/TokenStorageScopeTest.php
@@ -16,7 +16,7 @@ final class TokenStorageScopeTest extends TestCase
     {
         $storage = $this->createMock(TokenStorageInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('load')
             ->with('foo')
             ->willReturn($token = $this->createMock(TokenInterface::class));
@@ -35,7 +35,7 @@ final class TokenStorageScopeTest extends TestCase
 
         $storage = $this->createMock(TokenStorageInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('create')
             ->with(['foo' => 'bar'], $expiresAt)
             ->willReturn($token = $this->createMock(TokenInterface::class));
@@ -54,7 +54,7 @@ final class TokenStorageScopeTest extends TestCase
 
         $storage = $this->createMock(TokenStorageInterface::class);
         $storage
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('delete')
             ->with($token);
 

--- a/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
+++ b/tests/Framework/Bootloader/Debug/DebugBootloaderTest.php
@@ -85,7 +85,7 @@ final class DebugBootloaderTest extends BaseTestCase
     public function testGetCollectorsFromConfig(): void
     {
         $collector = $this->createMock(StateCollectorInterface::class);
-        $collector->expects($this->once())->method('populate');
+        $collector->expects(self::once())->method('populate');
 
         $this->getContainer()->bindSingleton('foo', $collector);
 

--- a/tests/Framework/Command/Router/ListCommandTest.php
+++ b/tests/Framework/Command/Router/ListCommandTest.php
@@ -14,43 +14,34 @@ final class ListCommandTest extends ConsoleTestCase
 
         // Anchor each name to the Name column (preceded by a column border, followed by padding + border)
         // so that e.g. `intercepted:without` is not matched inside `intercepted:withoutAttribute`.
-        $this->assertMatchesRegularExpression('/\|\s+auth\s+\|/', $output);
-        $this->assertMatchesRegularExpression('/\|\s+scope\s+\|/', $output);
-        $this->assertMatchesRegularExpression('/\|\s+intercepted:without\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+auth\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+scope\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+intercepted:without\s+\|/', $output);
     }
 
     public function testAllVerbsShownAsWildcard(): void
     {
         // A route accepting all verbs renders `*` as its own Verbs cell (between two borders),
         // distinct from target wildcards such as `AuthController->*`.
-        $this->assertMatchesRegularExpression('/\|\s+\*\s+\|/', $this->runCommand('route:list'));
+        self::assertMatchesRegularExpression('/\|\s+\*\s+\|/', $this->runCommand('route:list'));
     }
 
     public function testControllerTargetFormat(): void
     {
         // `auth` route -> Controller target rendered as `Controller\AuthController->*` in the Target cell.
-        $this->assertMatchesRegularExpression(
-            '/\\\\AuthController->\*\s+\|/',
-            $this->runCommand('route:list'),
-        );
+        self::assertMatchesRegularExpression('/\\\\AuthController->\*\s+\|/', $this->runCommand('route:list'));
     }
 
     public function testActionTargetFormat(): void
     {
         // `intercepted:without` -> Action target. Anchor to the cell border so it is not matched
         // inside `InterceptedController->withoutAttribute`.
-        $this->assertMatchesRegularExpression(
-            '/\\\\InterceptedController->without\s+\|/',
-            $this->runCommand('route:list'),
-        );
+        self::assertMatchesRegularExpression('/\\\\InterceptedController->without\s+\|/', $this->runCommand('route:list'));
     }
 
     public function testClosureTargetFormat(): void
     {
-        $this->assertMatchesRegularExpression(
-            '/Closure\(api\.php:\d+\)/',
-            $this->runCommand('route:list'),
-        );
+        self::assertMatchesRegularExpression('/Closure\(api\.php:\d+\)/', $this->runCommand('route:list'));
     }
 
     public function testRouteGroupAppearsInOutput(): void
@@ -59,8 +50,8 @@ final class ListCommandTest extends ConsoleTestCase
 
         // Tie the group value to a concrete route row (name ... | group |) so an empty/wrong
         // Group column cannot pass just because `api`/`other` appear in patterns or targets.
-        $this->assertMatchesRegularExpression('/\|\s+api\.test-import-index\s+\|.*\|\s*api\s+\|/', $output);
-        $this->assertMatchesRegularExpression('/\|\s+test-import-index\s+\|.*\|\s*other\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+api\.test-import-index\s+\|.*\|\s*api\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+test-import-index\s+\|.*\|\s*other\s+\|/', $output);
     }
 
     public function testPatternWithPrefixAppearsInOutput(): void
@@ -69,8 +60,8 @@ final class ListCommandTest extends ConsoleTestCase
 
         // Anchor to the Pattern cell so the prefixed index pattern is not matched inside the longer
         // `api/test-import/posts` pattern.
-        $this->assertMatchesRegularExpression('/\|\s+api\/test-import\s+\|/', $output);
-        $this->assertMatchesRegularExpression('/\|\s+other\/test-import\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+api\/test-import\s+\|/', $output);
+        self::assertMatchesRegularExpression('/\|\s+other\/test-import\s+\|/', $output);
     }
 
     public function testGetVerbDisplay(): void
@@ -125,9 +116,6 @@ final class ListCommandTest extends ConsoleTestCase
      */
     private function assertVerbForRoute(string $name, string $verb): void
     {
-        $this->assertMatchesRegularExpression(
-            \sprintf('/\|\s+%s\s+\|\s+%s\b/', \preg_quote($name, '/'), \preg_quote($verb, '/')),
-            $this->runCommand('route:list'),
-        );
+        self::assertMatchesRegularExpression(\sprintf('/\|\s+%s\s+\|\s+%s\b/', \preg_quote($name, '/'), \preg_quote($verb, '/')), $this->runCommand('route:list'));
     }
 }

--- a/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
+++ b/tests/Framework/Console/Confirmation/ApplicationInProductionTest.php
@@ -41,8 +41,8 @@ final class ApplicationInProductionTest extends TestCase
             $this->createStub(OutputInterface::class),
         );
 
-        $input->expects($this->once())->method('hasOption')->willReturn(true);
-        $input->expects($this->once())->method('getOption')->willReturn(true);
+        $input->expects(self::once())->method('hasOption')->willReturn(true);
+        $input->expects(self::once())->method('getOption')->willReturn(true);
 
         self::assertTrue($confirmation->confirmToProceed());
     }
@@ -55,9 +55,9 @@ final class ApplicationInProductionTest extends TestCase
             $output = $this->createMock(SymfonyStyle::class),
         );
 
-        $input->expects($this->once())->method('hasOption')->willReturn(false);
+        $input->expects(self::once())->method('hasOption')->willReturn(false);
         $output
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('confirm')
             ->with('Do you really wish to run command?', false)
             ->willReturn(true);
@@ -73,9 +73,9 @@ final class ApplicationInProductionTest extends TestCase
             $output = $this->createMock(SymfonyStyle::class),
         );
 
-        $input->expects($this->once())->method('hasOption')->willReturn(false);
+        $input->expects(self::once())->method('hasOption')->willReturn(false);
         $output
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('confirm')
             ->with('Do you really wish to run command?', false)
             ->willReturn(false);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR enable PreferPHPUnitSelfCallRector

<!-- Describe what has changed in this PR -->

## Why?

To changes PHPUnit calls from $this->assert*() to self::assert*()

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
