### PR TITLE
Enable RemoveNullArgOnNullDefaultParamRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -130,7 +130,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector::class,
         \Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
         \Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector::class,

--- a/rector.php
+++ b/rector.php
@@ -129,6 +129,11 @@ return RectorConfig::configure()
             __DIR__ . '/src/Models/tests/PublicEntity.php',
         ],
 
+        \Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector::class => [
+            // use of func_num_args() to detect if argument is passed or not
+            __DIR__ . '/src/Reactor/tests/Partial/MethodTest.php',
+        ],
+
         // to be enabled later for easier to review
         \Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
         \Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector::class,

--- a/src/AuthHttp/src/Transport/CookieTransport.php
+++ b/src/AuthHttp/src/Transport/CookieTransport.php
@@ -75,7 +75,7 @@ final class CookieTransport implements HttpTransportInterface
     public function removeToken(Request $request, Response $response, string $tokenID): Response
     {
         // reset to null
-        return $this->commitToken($request, $response, null, null);
+        return $this->commitToken($request, $response);
     }
 
     /**

--- a/src/Broadcasting/tests/Middleware/AuthorizationMiddlewareTest.php
+++ b/src/Broadcasting/tests/Middleware/AuthorizationMiddlewareTest.php
@@ -34,7 +34,6 @@ final class AuthorizationMiddlewareTest extends TestCase
         $middleware = new AuthorizationMiddleware(
             m::mock(BroadcastInterface::class),
             m::mock(ResponseFactoryInterface::class),
-            null,
         );
 
         $request = m::mock(ServerRequestInterface::class);

--- a/src/Http/tests/ServerTest.php
+++ b/src/Http/tests/ServerTest.php
@@ -118,9 +118,9 @@ final class ServerTest extends TestCase
 
         self::assertSame([
             'PATH' => 'sample',
-        ], $this->input->server->fetch(['path'], true, null));
+        ], $this->input->server->fetch(['path'], true));
 
-        self::assertSame(['PATH' => 'sample', 'OTHER' => null], $this->input->server->fetch(['path', 'other'], true, null));
+        self::assertSame(['PATH' => 'sample', 'OTHER' => null], $this->input->server->fetch(['path', 'other'], true));
     }
 
     public function testServerBagCount(): void

--- a/src/Reactor/tests/Partial/MethodTest.php
+++ b/src/Reactor/tests/Partial/MethodTest.php
@@ -241,7 +241,7 @@ final class MethodTest extends TestCase
     public function testAddPromotedParameterWithDefaultNullValue(): void
     {
         $method = new Method('test');
-        $param = $method->addPromotedParameter('test');
+        $param = $method->addPromotedParameter('test', null);
         $param->setNullable();
 
         self::assertTrue($param->hasDefaultValue());

--- a/src/Reactor/tests/Partial/MethodTest.php
+++ b/src/Reactor/tests/Partial/MethodTest.php
@@ -241,7 +241,7 @@ final class MethodTest extends TestCase
     public function testAddPromotedParameterWithDefaultNullValue(): void
     {
         $method = new Method('test');
-        $param = $method->addPromotedParameter('test', null);
+        $param = $method->addPromotedParameter('test');
         $param->setNullable();
 
         self::assertTrue($param->hasDefaultValue());

--- a/src/Stempler/src/Compiler/Renderer/CoreRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/CoreRenderer.php
@@ -43,7 +43,7 @@ final class CoreRenderer implements RendererInterface
                     static function (Compiler\Result $source) use ($node, $compiler): void {
                         foreach ($node->nodes as $child) {
                             if (\is_string($child)) {
-                                $source->push($child, null);
+                                $source->push($child);
                                 continue;
                             }
 

--- a/src/Stempler/src/Compiler/Renderer/HTMLRenderer.php
+++ b/src/Stempler/src/Compiler/Renderer/HTMLRenderer.php
@@ -44,21 +44,21 @@ final class HTMLRenderer implements RendererInterface
             $this->attribute($compiler, $result, $attr);
         }
 
-        $result->push(\sprintf('%s>', $node->void ? '/' : ''), null);
+        $result->push(\sprintf('%s>', $node->void ? '/' : ''));
 
         foreach ($node->nodes as $child) {
             $compiler->compile($child, $result);
         }
 
         if (!$node->void) {
-            $result->push(\sprintf('</%s>', $node->name), null);
+            $result->push(\sprintf('</%s>', $node->name));
         }
     }
 
     private function attribute(Compiler $compiler, Compiler\Result $result, Attr $node): void
     {
         if ($node->name instanceof NodeInterface) {
-            $result->push(' ', null);
+            $result->push(' ');
             $compiler->compile($node->name, $result);
         } else {
             $result->push(\sprintf(' %s', $node->name), $node->getContext());
@@ -70,7 +70,7 @@ final class HTMLRenderer implements RendererInterface
         }
 
         if ($value instanceof NodeInterface) {
-            $result->push('=', null);
+            $result->push('=');
             $compiler->compile($value, $result);
             return;
         }
@@ -82,7 +82,7 @@ final class HTMLRenderer implements RendererInterface
     {
         foreach ($node->nodes as $child) {
             if (\is_string($child)) {
-                $result->push($child, null);
+                $result->push($child);
                 continue;
             }
 

--- a/src/Storage/tests/Config/StorageConfigTest.php
+++ b/src/Storage/tests/Config/StorageConfigTest.php
@@ -38,8 +38,6 @@ final class StorageConfigTest extends TestCase
                 'credentials' => new Credentials(
                     'test-key',
                     'test-secret',
-                    null,
-                    null,
                 ),
                 'use_path_style_endpoint' => true,
             ]),
@@ -81,8 +79,6 @@ final class StorageConfigTest extends TestCase
                 'credentials' => new Credentials(
                     'test-key',
                     'test-secret',
-                    null,
-                    null,
                 ),
                 'use_path_style_endpoint' => true,
             ]),
@@ -126,8 +122,6 @@ final class StorageConfigTest extends TestCase
                 'credentials' => new Credentials(
                     'test-key',
                     'test-secret',
-                    null,
-                    null,
                 ),
                 'use_path_style_endpoint' => true,
             ]),
@@ -171,8 +165,6 @@ final class StorageConfigTest extends TestCase
                 'credentials' => new Credentials(
                     'test-key',
                     'test-secret',
-                    null,
-                    null,
                 ),
                 'use_path_style_endpoint' => true,
             ]),
@@ -216,8 +208,6 @@ final class StorageConfigTest extends TestCase
                 'credentials' => new Credentials(
                     'test-key',
                     'test-secret',
-                    null,
-                    null,
                 ),
                 'use_path_style_endpoint' => true,
             ]),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Remove default null argument, where null is already a default param value

<!-- Describe what has changed in this PR -->

## Why?

If null argument is equal with default param, no need to add it as argument.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
