### PR TITLE
Apply fix psr-4 namespaces under src/*/tests

### DIFF
--- a/src/Events/tests/EventDispatcherTest.php
+++ b/src/Events/tests/EventDispatcherTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\Events\Interceptor;
+namespace Spiral\Tests\Events;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/src/Http/tests/InputManagerTest.php
+++ b/src/Http/tests/InputManagerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\Http\Request;
+namespace Spiral\Tests\Http;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/src/Interceptors/tests/Unit/Handler/CallableHandlerTest.php
+++ b/src/Interceptors/tests/Unit/Handler/CallableHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Interceptors\Unit\Handler;
+namespace Spiral\Tests\Interceptors\Unit\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Interceptors\Context\CallContext;

--- a/src/Queue/tests/Interceptor/Consume/HandlerTest.php
+++ b/src/Queue/tests/Interceptor/Consume/HandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Spiral\Tests\Queue\Interceptor;
+namespace Spiral\Tests\Queue\Interceptor\Consume;
 
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/src/Scaffolder/tests/Command/InfoCommandTest.php
+++ b/src/Scaffolder/tests/Command/InfoCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Command;
+namespace Spiral\Tests\Scaffolder\Command;
 
 use Spiral\Tests\Scaffolder\Command\AbstractCommandTestCase;
 

--- a/structarmed.php
+++ b/structarmed.php
@@ -131,9 +131,18 @@ $ruleset = [
 
 $architecture = Architecture::define()
     ->skipPaths([
-        // per src/ has own autoload-dev which needs to their tests directory need to be skipped
-        // or may require special handling for it
-        'src/*/tests',
+        // fixtures
+        'src/Tokenizer/tests/Enums',
+        'src/Tokenizer/tests/Interfaces',
+        'src/Tokenizer/tests/Classes',
+        'src/Scaffolder/tests/App/config',
+
+        // multiple classes in one file on purpose
+        'src/Tokenizer/tests/ReflectionFileTest.php',
+        'src/Core/tests/Internal/Proxy/ProxyClassRendererTest.php',
+
+        // uses as bootstrapping
+        'src/Core/tests/bootstrap.php',
     ])
     ->ruleset($ruleset);
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied fix of psr-4 namespaces under `src/*/tests` detected by StructArmed enable to them.

<!-- Describe what has changed in this PR -->

## Why?

The test namespaces should match their paths/autoload configuration.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
