### PR TITLE
Enable AddInstanceofAssertForNullableInstanceRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -135,8 +135,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\PHPUnit\PHPUnit120\Rector\ClassMethod\ExpressionCreateMockToCreateStubRector::class,
-        \Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector::class,
         \Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector::class,
         \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class,

--- a/src/Boot/tests/ConfigsTest.php
+++ b/src/Boot/tests/ConfigsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Boot;
 
+use Spiral\Boot\AbstractKernel;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Tests\Boot\Fixtures\TestConfig;
 use Spiral\Tests\Boot\Fixtures\TestCore;
@@ -16,6 +17,7 @@ final class ConfigsTest extends TestCase
             'root'   => __DIR__,
             'config' => __DIR__ . '/config',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var TestConfig $config */
         $config = $core->getContainer()->get(TestConfig::class);
@@ -29,6 +31,7 @@ final class ConfigsTest extends TestCase
             'root'   => __DIR__,
             'config' => __DIR__ . '/config',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var ConfiguratorInterface $configurator */
         $configurator = $core->getContainer()->get(ConfiguratorInterface::class);

--- a/src/Boot/tests/DirectoriesTest.php
+++ b/src/Boot/tests/DirectoriesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\DirectoriesInterface;
 use Spiral\Boot\Exception\BootException;
 use Spiral\Boot\Exception\DirectoryException;
@@ -17,6 +18,7 @@ final class DirectoriesTest extends TestCase
         $core = TestCore::create([
             'root' => __DIR__,
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /**
          * @var DirectoriesInterface $dirs
@@ -48,6 +50,7 @@ final class DirectoriesTest extends TestCase
         $core = TestCore::create([
             'root' => __DIR__,
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /**
          * @var DirectoriesInterface $dirs
@@ -63,6 +66,7 @@ final class DirectoriesTest extends TestCase
         $core = TestCore::create([
             'root' => __DIR__,
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /**
          * @var DirectoriesInterface $dirs
@@ -83,6 +87,7 @@ final class DirectoriesTest extends TestCase
         $core = TestCore::create([
             'root' => __DIR__,
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /**
          * @var DirectoriesInterface $dirs

--- a/src/Boot/tests/FunctionsTest.php
+++ b/src/Boot/tests/FunctionsTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Environment;
 use Spiral\Core\Exception\ScopeException;
 use Spiral\Tests\Boot\Fixtures\TestConfig;
@@ -20,6 +21,7 @@ final class FunctionsTest extends TestCase
             'root'   => __DIR__,
             'config' => __DIR__ . '/config',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var ContainerInterface $c */
         $c = $core->getContainer();
@@ -37,6 +39,7 @@ final class FunctionsTest extends TestCase
         ])->run(new Environment([
             'key' => '(true)',
         ]));
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var ContainerInterface $c */
         $c = $core->getContainer();
@@ -52,6 +55,7 @@ final class FunctionsTest extends TestCase
             'root'   => __DIR__,
             'config' => __DIR__ . '/config',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var ContainerInterface $c */
         $c = $core->getContainer();
@@ -76,6 +80,7 @@ final class FunctionsTest extends TestCase
             'root'   => __DIR__,
             'config' => __DIR__ . '/config',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var ContainerInterface $c */
         $c = $core->getContainer();

--- a/src/Boot/tests/KernelTest.php
+++ b/src/Boot/tests/KernelTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\BootloadManager\StrategyBasedBootloadManager;
 use Spiral\Boot\BootloadManager\DefaultInvokerStrategy;
 use Spiral\Boot\BootloadManager\Initializer;
@@ -35,6 +36,7 @@ final class KernelTest extends TestCase
         $this->expectException(BootException::class);
 
         $kernel = TestCore::create(['root' => __DIR__])->run();
+        self::assertInstanceOf(AbstractKernel::class, $kernel);
 
         $kernel->serve();
     }
@@ -57,6 +59,7 @@ final class KernelTest extends TestCase
                 return true;
             }
         };
+        self::assertInstanceOf(AbstractKernel::class, $kernel);
         $kernel->addDispatcher($d);
 
         self::assertTrue($kernel->serve());
@@ -77,6 +80,7 @@ final class KernelTest extends TestCase
                 return true;
             }
         };
+        self::assertInstanceOf(AbstractKernel::class, $kernel);
         $kernel->addDispatcher($d);
 
         self::assertTrue($kernel->serve());
@@ -100,6 +104,7 @@ final class KernelTest extends TestCase
                 return 1;
             }
         };
+        self::assertInstanceOf(AbstractKernel::class, $kernel);
         $kernel->addDispatcher($d);
 
         $result = $kernel->serve();
@@ -112,6 +117,7 @@ final class KernelTest extends TestCase
     public function testEnv(): void
     {
         $kernel = TestCore::create(['root' => __DIR__])->run();
+        self::assertInstanceOf(AbstractKernel::class, $kernel);
 
         self::assertSame('VALUE', $kernel->getContainer()->get(EnvironmentInterface::class)->get('INTERNAL'));
     }

--- a/src/Boot/tests/MemoryTest.php
+++ b/src/Boot/tests/MemoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Boot;
 
 use PHPUnit\Framework\TestCase;
+use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\MemoryInterface;
 use Spiral\Tests\Boot\Fixtures\TestCore;
 
@@ -16,6 +17,7 @@ final class MemoryTest extends TestCase
             'root'  => __DIR__,
             'cache' => __DIR__ . '/cache',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var MemoryInterface $memory */
         $memory = $core->getContainer()->get(MemoryInterface::class);
@@ -34,6 +36,7 @@ final class MemoryTest extends TestCase
             'root'  => __DIR__,
             'cache' => __DIR__ . '/cache',
         ])->run();
+        self::assertInstanceOf(AbstractKernel::class, $core);
 
         /** @var MemoryInterface $memory */
         $memory = $core->getContainer()->get(MemoryInterface::class);

--- a/src/Router/tests/MiddlewareTest.php
+++ b/src/Router/tests/MiddlewareTest.php
@@ -9,6 +9,7 @@ use Nyholm\Psr7\Uri;
 use Psr\Container\NotFoundExceptionInterface;
 use Spiral\Router\Exception\RouteException;
 use Spiral\Router\Route;
+use Spiral\Router\RouteInterface;
 use Spiral\Router\Target\Group;
 use Spiral\Router\UriHandler;
 use Spiral\Tests\Router\Diactoros\UriFactory;
@@ -119,6 +120,7 @@ final class MiddlewareTest extends BaseTestingCase
         $r = $r->withUriHandler(new UriHandler(new UriFactory()));
 
         $r = $r->match(new ServerRequest('GET', new Uri('/test')));
+        self::assertInstanceOf(RouteInterface::class, $r);
         $response = $r->handle(new ServerRequest('GET', new Uri('/test')));
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('hello world', (string) $response->getBody());

--- a/src/Router/tests/PatternsTest.php
+++ b/src/Router/tests/PatternsTest.php
@@ -27,6 +27,7 @@ final class PatternsTest extends TestCase
         $route = $route->withUriHandler(new UriHandler(new UriFactory()));
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://site.com/statistics/set/10/285/0')));
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'moduleType' => '10',
@@ -47,6 +48,7 @@ final class PatternsTest extends TestCase
         $match = $route->match(
             new ServerRequest('GET', new Uri('http://site.com/users/1')),
         );
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'int' => '1',
@@ -81,6 +83,7 @@ final class PatternsTest extends TestCase
         $match = $route->match(
             new ServerRequest('GET', new Uri('http://site.com/users/1')),
         );
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'integer' => '1',
@@ -115,6 +118,7 @@ final class PatternsTest extends TestCase
         $match = $route->match(
             new ServerRequest('GET', new Uri('http://site.com/users/34f7b660-7ad0-11ed-a1eb-0242ac120002')),
         );
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'uuid' => '34f7b660-7ad0-11ed-a1eb-0242ac120002',
@@ -161,6 +165,7 @@ final class PatternsTest extends TestCase
         $match = $route->match(
             new ServerRequest('GET', new Uri('http://site.com/users/34f7b660-7ad0-11ed-a1eb-0242ac222222')),
         );
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'uuid' => '34f7b660-7ad0-11ed-a1eb-0242ac222222',
@@ -201,10 +206,12 @@ final class PatternsTest extends TestCase
         $match2 = $route->match(
             new ServerRequest('GET', new Uri('http://site.com/users/baz')),
         );
+        self::assertInstanceOf(Route::class, $match);
 
         self::assertSame([
             'name' => 'foo',
         ], $match->getMatches());
+        self::assertInstanceOf(Route::class, $match1);
         self::assertSame([
             'name' => 'bar',
         ], $match1->getMatches());

--- a/src/Router/tests/SubdomainTest.php
+++ b/src/Router/tests/SubdomainTest.php
@@ -24,9 +24,11 @@ final class SubdomainTest extends TestCase
         $route = $route->withUriHandler(new UriHandler(new UriFactory()));
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://site.com/foo')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'subdomain'], $match->getMatches());
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://bar.site.com/foo')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'bar'], $match->getMatches());
     }
 
@@ -41,15 +43,19 @@ final class SubdomainTest extends TestCase
         $route = $route->withUriHandler(new UriHandler(new UriFactory()));
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://site.com/foo/bar')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'subdomain', 'action' => 'bar'], $match->getMatches());
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://site.com/foo')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'subdomain', 'action' => null], $match->getMatches());
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://bar.site.com/foo')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'bar', 'action' => null], $match->getMatches());
 
         $match = $route->match(new ServerRequest('GET', new Uri('http://bar.site.com/foo/bar')));
+        self::assertInstanceOf(Route::class, $match);
         self::assertSame(['sub' => 'bar', 'action' => 'bar'], $match->getMatches());
     }
 }

--- a/src/Stempler/tests/Transform/Import/DirectoryTest.php
+++ b/src/Stempler/tests/Transform/Import/DirectoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Spiral\Stempler\Builder;
 use Spiral\Stempler\Loader\LoaderInterface;
 use Spiral\Stempler\Loader\Source;
+use Spiral\Stempler\Node\Template;
 use Spiral\Stempler\Transform\Import\Directory;
 use Spiral\Tests\Stempler\Transform\BaseTestCase;
 
@@ -57,6 +58,7 @@ final class DirectoryTest extends BaseTestCase
             ->andReturn(new Source('<span></span>'));
 
         $template = $directory->resolve(new Builder($loader), $tag);
+        self::assertInstanceOf(Template::class, $template);
 
         self::assertSame($path, $template->getContext()->getPath());
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add explicit instance assert between nullable object assign and method call on nullable object.

<!-- Describe what has changed in this PR -->

## Why?

Adding an explicit instance assertion gives static analysis a precise type boundary before the method is called.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually

