### PR TITLE
Enable TypedPropertyFromCreateMockAssignRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -135,8 +135,6 @@ return RectorConfig::configure()
         ],
 
         // to be enabled later for easier to review
-        \Rector\PHPUnit\CodeQuality\Rector\ClassMethod\BareCreateMockAssignToDirectUseRector::class,
-        \Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector::class,
         \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\WithCallbackIdenticalToStandaloneAssertsRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector::class,

--- a/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
@@ -24,11 +24,11 @@ use Spiral\Router\Exception\RouterException;
 
 final class ErrorHandlerMiddlewareTest extends TestCase
 {
-    private MockObject $handler;
+    private MockObject&RequestHandlerInterface $handler;
     private ServerRequestInterface $request;
-    private MockObject $exceptionHandler;
-    private MockObject $logger;
-    private MockObject $renderer;
+    private MockObject&ExceptionHandlerInterface $exceptionHandler;
+    private MockObject&LoggerInterface $logger;
+    private MockObject&RendererInterface $renderer;
 
     public static function exceptionsDataProvider(): \Traversable
     {

--- a/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
@@ -23,11 +23,11 @@ use Spiral\Router\Exception\RouterException;
 
 final class ErrorHandlerMiddlewareTest extends TestCase
 {
-    private RequestHandlerInterface $handler;
+    private \PHPUnit\Framework\MockObject\MockObject $handler;
     private ServerRequestInterface $request;
-    private ExceptionHandlerInterface $exceptionHandler;
-    private LoggerInterface $logger;
-    private RendererInterface $renderer;
+    private \PHPUnit\Framework\MockObject\MockObject $exceptionHandler;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $renderer;
 
     public static function exceptionsDataProvider(): \Traversable
     {

--- a/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/src/Http/tests/Middleware/ErrorHandlerMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace Spiral\Tests\Http\Middleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -23,11 +24,11 @@ use Spiral\Router\Exception\RouterException;
 
 final class ErrorHandlerMiddlewareTest extends TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $handler;
+    private MockObject $handler;
     private ServerRequestInterface $request;
-    private \PHPUnit\Framework\MockObject\MockObject $exceptionHandler;
-    private \PHPUnit\Framework\MockObject\MockObject $logger;
-    private \PHPUnit\Framework\MockObject\MockObject $renderer;
+    private MockObject $exceptionHandler;
+    private MockObject $logger;
+    private MockObject $renderer;
 
     public static function exceptionsDataProvider(): \Traversable
     {

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Queue\Interceptor\Consume;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Spiral\Attributes\ReaderInterface;
 use Spiral\Core\CoreInterface;
@@ -22,8 +23,8 @@ use Spiral\Tests\Queue\TestCase;
 
 final class RetryPolicyInterceptorTest extends TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $reader;
-    private \PHPUnit\Framework\MockObject\MockObject $core;
+    private MockObject $reader;
+    private MockObject $core;
     private RetryPolicyInterceptor $interceptor;
 
     public static function jobNameDataProvider(): \Traversable

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -22,8 +22,8 @@ use Spiral\Tests\Queue\TestCase;
 
 final class RetryPolicyInterceptorTest extends TestCase
 {
-    private ReaderInterface $reader;
-    private CoreInterface $core;
+    private \PHPUnit\Framework\MockObject\MockObject $reader;
+    private \PHPUnit\Framework\MockObject\MockObject $core;
     private RetryPolicyInterceptor $interceptor;
 
     public static function jobNameDataProvider(): \Traversable

--- a/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
+++ b/src/Queue/tests/Interceptor/Consume/RetryPolicyInterceptorTest.php
@@ -23,8 +23,8 @@ use Spiral\Tests\Queue\TestCase;
 
 final class RetryPolicyInterceptorTest extends TestCase
 {
-    private MockObject $reader;
-    private MockObject $core;
+    private MockObject&ReaderInterface $reader;
+    private MockObject&CoreInterface $core;
     private RetryPolicyInterceptor $interceptor;
 
     public static function jobNameDataProvider(): \Traversable

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -24,7 +24,7 @@ use Spiral\Telemetry\NullTracer;
 
 final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    private MockObject $container;
+    private MockObject&ContainerInterface $container;
     private FactoryInterface $factory;
     private PipelineFactory $pipeline;
 

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Router;
 
 use Mockery as m;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,7 +24,7 @@ use Spiral\Telemetry\NullTracer;
 
 final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $container;
+    private MockObject $container;
     private FactoryInterface $factory;
     private PipelineFactory $pipeline;
 

--- a/src/Router/tests/PipelineFactoryTest.php
+++ b/src/Router/tests/PipelineFactoryTest.php
@@ -23,7 +23,7 @@ use Spiral\Telemetry\NullTracer;
 
 final class PipelineFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    private ContainerInterface $container;
+    private \PHPUnit\Framework\MockObject\MockObject $container;
     private FactoryInterface $factory;
     private PipelineFactory $pipeline;
 

--- a/src/Snapshots/tests/StorageSnapshotTest.php
+++ b/src/Snapshots/tests/StorageSnapshotTest.php
@@ -14,10 +14,10 @@ use Spiral\Storage\StorageInterface;
 
 final class StorageSnapshotTest extends TestCase
 {
-    private ExceptionRendererInterface $renderer;
-    private FileInterface $file;
-    private BucketInterface $bucket;
-    private StorageInterface $storage;
+    private \PHPUnit\Framework\MockObject\MockObject $renderer;
+    private \PHPUnit\Framework\MockObject\MockObject $file;
+    private \PHPUnit\Framework\MockObject\MockObject $bucket;
+    private \PHPUnit\Framework\MockObject\MockObject $storage;
 
     protected function setUp(): void
     {

--- a/src/Snapshots/tests/StorageSnapshotTest.php
+++ b/src/Snapshots/tests/StorageSnapshotTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Snapshots;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Spiral\Exceptions\ExceptionRendererInterface;
 use Spiral\Exceptions\Verbosity;
 use Spiral\Snapshots\StorageSnapshot;
@@ -14,10 +15,10 @@ use Spiral\Storage\StorageInterface;
 
 final class StorageSnapshotTest extends TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $renderer;
-    private \PHPUnit\Framework\MockObject\MockObject $file;
-    private \PHPUnit\Framework\MockObject\MockObject $bucket;
-    private \PHPUnit\Framework\MockObject\MockObject $storage;
+    private MockObject $renderer;
+    private MockObject $file;
+    private MockObject $bucket;
+    private MockObject $storage;
 
     protected function setUp(): void
     {

--- a/src/Snapshots/tests/StorageSnapshotTest.php
+++ b/src/Snapshots/tests/StorageSnapshotTest.php
@@ -15,10 +15,10 @@ use Spiral\Storage\StorageInterface;
 
 final class StorageSnapshotTest extends TestCase
 {
-    private MockObject $renderer;
-    private MockObject $file;
-    private MockObject $bucket;
-    private MockObject $storage;
+    private MockObject&ExceptionRendererInterface $renderer;
+    private MockObject&FileInterface $file;
+    private MockObject&BucketInterface $bucket;
+    private MockObject&StorageInterface $storage;
 
     protected function setUp(): void
     {

--- a/src/Snapshots/tests/StorageSnapshotTest.php
+++ b/src/Snapshots/tests/StorageSnapshotTest.php
@@ -59,7 +59,7 @@ final class StorageSnapshotTest extends TestCase
         self::assertStringContainsString('Error', $s->getMessage());
         self::assertStringContainsString('message', $s->getMessage());
         self::assertStringContainsString(__FILE__, $s->getMessage());
-        self::assertStringContainsString('53', $s->getMessage());
+        self::assertStringContainsString('54', $s->getMessage());
     }
 
     public function testCreateWithDirectory(): void
@@ -79,6 +79,6 @@ final class StorageSnapshotTest extends TestCase
         self::assertStringContainsString('Error', $s->getMessage());
         self::assertStringContainsString('message', $s->getMessage());
         self::assertStringContainsString(__FILE__, $s->getMessage());
-        self::assertStringContainsString('72', $s->getMessage());
+        self::assertStringContainsString('73', $s->getMessage());
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add `PHPUnit\Framework\MockObject\MockObject` typed property from assigned mock to clearly separate from real objects

<!-- Describe what has changed in this PR -->

## Why?

- Makes test intent clearer by explicitly identifying properties that store PHPUnit mocks.
- Helps distinguish mocked dependencies from real objects at a glance.
- Improves IDE and static analysis support for mock-specific methods.
- Reduces ambiguity when maintaining or extending the tests later.
 
<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually


