### PR TITLE
Avoid chmod warnings when writing files into existing macOS temp directories

### DIFF
--- a/src/Files/src/Files.php
+++ b/src/Files/src/Files.php
@@ -280,7 +280,7 @@ final class Files implements FilesInterface
             $mode |= 0111;
         }
 
-        return $this->getPermissions($filename) === $mode || @\chmod($filename, $mode);
+        return $this->getPermissions($filename) === $mode || \chmod($filename, $mode);
     }
 
     public function getFiles(string $location, ?string $pattern = null): array

--- a/src/Files/src/Files.php
+++ b/src/Files/src/Files.php
@@ -96,9 +96,16 @@ final class Files implements FilesInterface
     ): bool {
         $mode ??= self::DEFAULT_FILE_MODE;
 
+        if ($this->isDirectory($filename)) {
+            throw new WriteErrorException(\sprintf('Unable to write file `%s`.', $filename));
+        }
+
         try {
             if ($ensureDirectory) {
-                $this->ensureDirectory(\dirname($filename), $mode);
+                $directory = \dirname($filename);
+                if (!$this->isDirectory($directory) || !\is_writable($directory)) {
+                    $this->ensureDirectory($directory, $mode);
+                }
             }
 
             if ($this->exists($filename)) {
@@ -106,21 +113,23 @@ final class Files implements FilesInterface
                 $this->setPermissions($filename, $mode);
             }
 
-            $result = \file_put_contents(
+            $result = @\file_put_contents(
                 $filename,
                 $data,
                 $append ? FILE_APPEND | LOCK_EX : LOCK_EX,
             );
 
-            if ($result !== false) {
-                //Forcing mode after file creation
-                $this->setPermissions($filename, $mode);
+            if ($result === false) {
+                throw new WriteErrorException(\sprintf('Unable to write file `%s`.', $filename));
             }
+
+            //Forcing mode after file creation
+            $this->setPermissions($filename, $mode);
         } catch (\Exception $e) {
             throw new WriteErrorException($e->getMessage(), (int) $e->getCode(), $e);
         }
 
-        return $result !== false;
+        return true;
     }
 
     public function append(
@@ -273,7 +282,7 @@ final class Files implements FilesInterface
             $mode |= 0111;
         }
 
-        return $this->getPermissions($filename) === $mode || \chmod($filename, $mode);
+        return $this->getPermissions($filename) === $mode || @\chmod($filename, $mode);
     }
 
     public function getFiles(string $location, ?string $pattern = null): array

--- a/src/Files/src/Files.php
+++ b/src/Files/src/Files.php
@@ -97,7 +97,7 @@ final class Files implements FilesInterface
         $mode ??= self::DEFAULT_FILE_MODE;
 
         if ($this->isDirectory($filename)) {
-            throw new WriteErrorException(\sprintf('Unable to write file `%s`.', $filename));
+            throw new WriteErrorException(\sprintf('Unable to write file `%s`, path is a directory.', $filename));
         }
 
         try {

--- a/src/Files/src/Files.php
+++ b/src/Files/src/Files.php
@@ -113,23 +113,21 @@ final class Files implements FilesInterface
                 $this->setPermissions($filename, $mode);
             }
 
-            $result = @\file_put_contents(
+            $result = \file_put_contents(
                 $filename,
                 $data,
                 $append ? FILE_APPEND | LOCK_EX : LOCK_EX,
             );
 
-            if ($result === false) {
-                throw new WriteErrorException(\sprintf('Unable to write file `%s`.', $filename));
+            if ($result !== false) {
+                //Forcing mode after file creation
+                $this->setPermissions($filename, $mode);
             }
-
-            //Forcing mode after file creation
-            $this->setPermissions($filename, $mode);
         } catch (\Exception $e) {
             throw new WriteErrorException($e->getMessage(), (int) $e->getCode(), $e);
         }
 
-        return true;
+        return $result !== false;
     }
 
     public function append(

--- a/src/Files/tests/IOTest.php
+++ b/src/Files/tests/IOTest.php
@@ -69,14 +69,8 @@ final class IOTest extends TestCase
 
         $files->ensureDirectory($directory, FilesInterface::READONLY);
 
-        if (!@\chmod($directory, 0555)) {
-            self::markTestSkipped('Unable to create a non-writable directory fixture.');
-        }
-
+        @\chmod($directory, 0555);
         \clearstatcache(false, $directory);
-        if (\is_writable($directory)) {
-            self::markTestSkipped('Unable to make the directory fixture non-writable.');
-        }
 
         try {
             $files->write($filename, 'some-data', FilesInterface::RUNTIME, true);

--- a/src/Files/tests/IOTest.php
+++ b/src/Files/tests/IOTest.php
@@ -45,6 +45,10 @@ final class IOTest extends TestCase
 
     public function testWriteAndEnsureDirectoryKeepsExistingDirectoryPermissions(): void
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('Unix file permissions are not enforced on Windows.');
+        }
+
         $files = new Files();
 
         $directory = self::FIXTURE_DIRECTORY . '/directory/';
@@ -62,6 +66,14 @@ final class IOTest extends TestCase
 
     public function testWriteAndEnsureDirectoryRepairsNotWritableDirectoryPermissions(): void
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('Unix file permissions are not enforced on Windows.');
+        }
+
+        if (\function_exists('posix_getuid') && \posix_getuid() === 0) {
+            self::markTestSkipped('Root bypasses directory write permissions.');
+        }
+
         $files = new Files();
 
         $directory = self::FIXTURE_DIRECTORY . '/directory/';

--- a/src/Files/tests/IOTest.php
+++ b/src/Files/tests/IOTest.php
@@ -43,6 +43,52 @@ final class IOTest extends TestCase
         self::assertSame('some-data', \file_get_contents($filename));
     }
 
+    public function testWriteAndEnsureDirectoryKeepsExistingDirectoryPermissions(): void
+    {
+        $files = new Files();
+
+        $directory = self::FIXTURE_DIRECTORY . '/directory/';
+        $filename = $directory . 'test.txt';
+
+        $files->ensureDirectory($directory, FilesInterface::READONLY);
+        self::assertSame(0755, $files->getPermissions($directory));
+
+        $files->write($filename, 'some-data', FilesInterface::RUNTIME, true);
+
+        self::assertSame(0755, $files->getPermissions($directory));
+        self::assertSame(FilesInterface::RUNTIME, $files->getPermissions($filename));
+        self::assertSame('some-data', \file_get_contents($filename));
+    }
+
+    public function testWriteAndEnsureDirectoryRepairsNotWritableDirectoryPermissions(): void
+    {
+        $files = new Files();
+
+        $directory = self::FIXTURE_DIRECTORY . '/directory/';
+        $filename = $directory . 'test.txt';
+
+        $files->ensureDirectory($directory, FilesInterface::READONLY);
+
+        if (!@\chmod($directory, 0555)) {
+            self::markTestSkipped('Unable to create a non-writable directory fixture.');
+        }
+
+        \clearstatcache(false, $directory);
+        if (\is_writable($directory)) {
+            self::markTestSkipped('Unable to make the directory fixture non-writable.');
+        }
+
+        try {
+            $files->write($filename, 'some-data', FilesInterface::RUNTIME, true);
+
+            self::assertSame(0777, $files->getPermissions($directory));
+            self::assertSame(FilesInterface::RUNTIME, $files->getPermissions($filename));
+            self::assertSame('some-data', \file_get_contents($filename));
+        } finally {
+            @\chmod($directory, 0777);
+        }
+    }
+
     public function testRead(): void
     {
         $files = new Files();

--- a/src/Files/tests/IOTest.php
+++ b/src/Files/tests/IOTest.php
@@ -68,6 +68,7 @@ final class IOTest extends TestCase
         $filename = $directory . 'test.txt';
 
         $files->ensureDirectory($directory, FilesInterface::READONLY);
+        $directoryMode = $files->getPermissions($directory);
 
         @\chmod($directory, 0555);
         \clearstatcache(false, $directory);
@@ -79,7 +80,7 @@ final class IOTest extends TestCase
             self::assertSame(FilesInterface::RUNTIME, $files->getPermissions($filename));
             self::assertSame('some-data', \file_get_contents($filename));
         } finally {
-            @\chmod($directory, 0777);
+            @\chmod($directory, $directoryMode);
         }
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

On macOS, running test with `--display-warnings` got warning:

```bash
vendor/bin/phpunit src/Session/tests/SessionTest.php  --display-warnings  

8 tests triggered 1 PHP warning:

1) /Users/samsonasik/www/spiral-framework/src/Files/src/Files.php:276
chmod(): Operation not permitted

Triggered by:

* Spiral\Tests\Session\SessionTest::testResumeAndID (4 times)
  /Users/samsonasik/www/spiral-framework/src/Session/tests/SessionTest.php:147
```

This PR updates Files::write() so ensureDirectory: true no longer blindly re-applies permissions to an existing writable parent directory. On macOS, sys_get_temp_dir() can point to a platform-managed temp directory where chmod() returns “Operation not permitted,” which surfaced as a PHPUnit warning in session tests.

<!-- Describe what has changed in this PR -->

## Why?

The warning was observed on macOS when session storage wrote into `sys_get_temp_dir()`. The underlying behavior belongs in `Files`.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
    - [x] Unit tests added
