### PR TITLE
Enable NarrowWideUnionReturnTypeRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -134,8 +134,13 @@ return RectorConfig::configure()
             __DIR__ . '/src/Reactor/tests/Partial/MethodTest.php',
         ],
 
+        \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class => [
+            // test 2 versions of monolog: v2 and v3 which
+            // Logger::API can be 2 or 3
+            __DIR__ . '/src/Bridge/Monolog/tests/HandlersTest.php',
+        ],
+
         // to be enabled later for easier to review
-        \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\WithCallbackIdenticalToStandaloneAssertsRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector::class,
         \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector::class,

--- a/src/Http/src/Header/AcceptHeader.php
+++ b/src/Http/src/Header/AcceptHeader.php
@@ -161,7 +161,7 @@ final class AcceptHeader implements \Stringable
             $item = AcceptHeaderItem::fromString($item);
         }
 
-        $value = \strtolower((string) $item->getValue());
+        $value = \strtolower($item->getValue());
         if ($value !== '' && (!$this->has($value) || self::compare($item, $this->get($value)) === 1)) {
             $this->sorted = false;
             $this->items[$value] = $item;

--- a/src/Http/src/Header/AcceptHeaderItem.php
+++ b/src/Http/src/Header/AcceptHeaderItem.php
@@ -65,7 +65,7 @@ final class AcceptHeaderItem implements \Stringable
         return $item;
     }
 
-    public function getValue(): ?string
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/src/Http/src/Request/InputManager.php
+++ b/src/Http/src/Request/InputManager.php
@@ -265,7 +265,7 @@ final class InputManager
 
         if ($softMatch) {
             foreach ($acceptHeader->getAll() as $item) {
-                $itemValue = \strtolower((string) $item->getValue());
+                $itemValue = \strtolower($item->getValue());
                 if (\str_ends_with($itemValue, '/json') || \str_ends_with($itemValue, '+json')) {
                     return true;
                 }

--- a/src/Prototype/src/NodeVisitors/UpdateConstructor.php
+++ b/src/Prototype/src/NodeVisitors/UpdateConstructor.php
@@ -19,7 +19,7 @@ final class UpdateConstructor extends NodeVisitorAbstract
         private readonly ClassNode $definition,
     ) {}
 
-    public function leaveNode(Node $node): int|Node|null
+    public function leaveNode(Node $node): ?Node
     {
         if (!$node instanceof Node\Stmt\Class_) {
             return null;

--- a/src/Router/tests/Loader/Configurator/RouteConfiguratorTest.php
+++ b/src/Router/tests/Loader/Configurator/RouteConfiguratorTest.php
@@ -96,7 +96,7 @@ final class RouteConfiguratorTest extends BaseTestCase
                 return '';
             }
 
-            protected function resolveAction(array $matches): ?string
+            protected function resolveAction(array $matches): string
             {
                 return '';
             }

--- a/src/Serializer/src/Serializer/JsonSerializer.php
+++ b/src/Serializer/src/Serializer/JsonSerializer.php
@@ -14,7 +14,7 @@ final class JsonSerializer implements SerializerInterface
     /**
      * @throws SerializeException
      */
-    public function serialize(mixed $payload): string|\Stringable
+    public function serialize(mixed $payload): string
     {
         try {
             return \json_encode($payload, JSON_THROW_ON_ERROR);

--- a/src/Serializer/src/Serializer/PhpSerializer.php
+++ b/src/Serializer/src/Serializer/PhpSerializer.php
@@ -10,7 +10,7 @@ use Spiral\Serializer\SerializerInterface;
 
 final class PhpSerializer implements SerializerInterface
 {
-    public function serialize(mixed $payload): string|\Stringable
+    public function serialize(mixed $payload): string
     {
         return \serialize($payload);
     }

--- a/src/Stempler/src/Transform/Finalizer/StackCollector.php
+++ b/src/Stempler/src/Transform/Finalizer/StackCollector.php
@@ -36,7 +36,7 @@ final class StackCollector implements VisitorInterface
         return null;
     }
 
-    private function registerPush(StackContext $ctx, Tag $node): int|Tag|null
+    private function registerPush(StackContext $ctx, Tag $node): ?int
     {
         $name = $this->stackName($node);
 
@@ -47,7 +47,7 @@ final class StackCollector implements VisitorInterface
         return self::REMOVE_NODE;
     }
 
-    private function registerPrepend(StackContext $ctx, Tag $node): int|Tag|null
+    private function registerPrepend(StackContext $ctx, Tag $node): ?int
     {
         $name = $this->stackName($node);
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Narrow overly wide union return type declaration if possible.

<!-- Describe what has changed in this PR -->

## Why?

Narrowing the union type better reflects the real behavior, improves type inference, and reduces unnecessary downstream checks without changing runtime behavior.

This only apply if:

- class is final class 
- class is not final, but method is private

so this is safe change.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
