### PR TITLE
Enable Rector TypeCoverageLevel 10

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -152,7 +152,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(5)
+    ->withTypeCoverageLevel(10)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/src/Router/tests/Call.php
+++ b/src/Router/tests/Call.php
@@ -6,7 +6,7 @@ namespace Spiral\Tests\Router;
 
 class Call
 {
-    public function __invoke()
+    public function __invoke(): string
     {
         return 'invoked';
     }

--- a/tests/app/src/Controller/AuthController.php
+++ b/tests/app/src/Controller/AuthController.php
@@ -14,7 +14,7 @@ class AuthController
 {
     public function __construct(private readonly AuthScope $auth) {}
 
-    public function do(GuardInterface $guard)
+    public function do(GuardInterface $guard): string
     {
         if (!$guard->allows('do')) {
             throw new ControllerException("Unauthorized permission 'do'", ControllerException::FORBIDDEN);
@@ -32,7 +32,7 @@ class AuthController
         return 'none';
     }
 
-    public function login(AuthContextInterface $authContext, TokenStorageInterface $tokenStorage)
+    public function login(AuthContextInterface $authContext, TokenStorageInterface $tokenStorage): string
     {
         $authContext->start(
             $tokenStorage->create(['userID' => 1]),
@@ -41,7 +41,7 @@ class AuthController
         return 'OK';
     }
 
-    public function logout()
+    public function logout(): string
     {
         $this->auth->close();
 
@@ -62,7 +62,7 @@ class AuthController
         return $this->auth->getToken()->getPayload();
     }
 
-    public function login2(TokenStorageInterface $tokenStorage)
+    public function login2(TokenStorageInterface $tokenStorage): string
     {
         $this->auth->start(
             $tokenStorage->create(['userID' => 1]),

--- a/tests/app/src/Controller/Demo2Controller.php
+++ b/tests/app/src/Controller/Demo2Controller.php
@@ -11,25 +11,25 @@ use Spiral\Domain\Annotation\GuardNamespace;
 class Demo2Controller
 {
     #[Guarded('do')]
-    public function do1()
+    public function do1(): string
     {
         return 'ok';
     }
 
     #[Guarded('do', else: 'notFound')]
-    public function do2()
+    public function do2(): string
     {
         return 'ok';
     }
 
     #[Guarded('do', else: 'error')]
-    public function do3()
+    public function do3(): string
     {
         return 'ok';
     }
 
     #[Guarded('do', else: 'badAction')]
-    public function do4()
+    public function do4(): string
     {
         return 'ok';
     }

--- a/tests/app/src/Controller/TestController.php
+++ b/tests/app/src/Controller/TestController.php
@@ -17,7 +17,7 @@ class TestController
 {
     use TranslatorTrait;
 
-    public function index(string $name = 'Dave')
+    public function index(string $name = 'Dave'): string
     {
         return "Hello, {$name}.";
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `StringReturnTypeFromStrictScalarReturnsRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add string return type based on returned string scalar values.

It seems applied on tests class methods so should be safe 👍 

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually