### PR TITLE
Bump Rector to ~2.4.6 and clean up skip config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.4.5",
+        "rector/rector": "~2.4.6",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/rector.php
+++ b/rector.php
@@ -129,11 +129,6 @@ return RectorConfig::configure()
             __DIR__ . '/src/Models/tests/PublicEntity.php',
         ],
 
-        \Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector::class => [
-            // use of func_num_args() to detect if argument is passed or not
-            __DIR__ . '/src/Reactor/tests/Partial/MethodTest.php',
-        ],
-
         \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class => [
             // test 2 versions of monolog: v2 and v3 which
             // Logger::API can be 2 or 3


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR bump Rector to ~2.4.6 and clean up skip config of `RemoveNullArgOnNullDefaultParamRector`.

<!-- Describe what has changed in this PR -->

## Why?

The skipped config already resolved on latest 2.4.6.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
