### PR TITLE
Enable Rector TypeCoverageLevel 13

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(10)
+    ->withTypeCoverageLevel(13)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/src/Config/tests/Value.php
+++ b/src/Config/tests/Value.php
@@ -8,7 +8,7 @@ class Value
 {
     public function __construct(private readonly string $value = 'value!') {}
 
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/tests/app/src/Controller/AuthController.php
+++ b/tests/app/src/Controller/AuthController.php
@@ -23,7 +23,7 @@ class AuthController
         return 'ok';
     }
 
-    public function token(AuthContextInterface $authContext)
+    public function token(AuthContextInterface $authContext): string
     {
         if ($authContext->getToken() !== null) {
             return $authContext->getToken()->getID();
@@ -48,7 +48,7 @@ class AuthController
         return 'closed';
     }
 
-    public function token2()
+    public function token2(): string
     {
         if ($this->auth->getToken() !== null) {
             return $this->auth->getToken()->getID();

--- a/tests/app/src/Controller/TestController.php
+++ b/tests/app/src/Controller/TestController.php
@@ -37,7 +37,7 @@ class TestController
 
     public function filter2(BadRequest $r): void {}
 
-    public function input(InputScope $i)
+    public function input(InputScope $i): string
     {
         return 'value: ' . $i->withPrefix('section')->getValue('query', 'value');
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `StringReturnTypeFromStrictStringReturnsRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add string return type based on returned strict string values.

It seems applied on tests class methods so should be safe 👍 

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually