### PR TITLE
Enable Rector TypeCoverageLevel 14

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(13)
+    ->withTypeCoverageLevel(14)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/src/Models/tests/GetEntity.php
+++ b/src/Models/tests/GetEntity.php
@@ -11,7 +11,7 @@ class GetEntity extends DataEntity
 {
     protected const GETTERS = ['id' => [self::class, 'filter']];
 
-    protected static function filter($v)
+    protected static function filter($v): int
     {
         if (\is_array($v)) {
             throw new RuntimeException("can't be array");

--- a/tests/app/src/Controller/TestController.php
+++ b/tests/app/src/Controller/TestController.php
@@ -57,7 +57,7 @@ class TestController
         return $request->getBody();
     }
 
-    public function required(int $id)
+    public function required(int $id): int
     {
         //no index
         $this->say(static::class);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `NumericReturnTypeFromStrictReturnsRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add int/float return type based on strict typed returns.

It seems applied on tests class methods so should be safe 👍 

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually