### PR TITLE
Enable Rector TypeCoverageLevel 16

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(14)
+    ->withTypeCoverageLevel(16)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/tests/app/src/Controller/TestController.php
+++ b/tests/app/src/Controller/TestController.php
@@ -30,7 +30,7 @@ class TestController
         return $p->withCount(1000)->getPage();
     }
 
-    public function filter(TestRequest $r)
+    public function filter(TestRequest $r): array
     {
         return ['name' => $r->name, 'sectionValue' => $r->sectionValue];
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `ReturnTypeFromReturnDirectArrayRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add return type from return direct array

It seems applied on tests class methods so should be safe 👍 

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually