### PR TITLE
Enable Rector TypeCoverageLevel 18

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -33,9 +33,6 @@
     </InvalidArgument>
   </file>
   <file src="src/Core/src/Internal/Actor.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$actor->registerInstance($ctx, $instance)]]></code>
-    </InvalidReturnStatement>
     <NoValue>
       <code><![CDATA[$injector]]></code>
       <code><![CDATA[$singleton]]></code>

--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(16)
+    ->withTypeCoverageLevel(18)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/src/Core/src/Internal/Actor.php
+++ b/src/Core/src/Internal/Actor.php
@@ -193,6 +193,13 @@ final class Actor
         return $this->createInstance($ctx, $arguments, $fallbackActor, $tracer);
     }
 
+    /**
+     * @template TObject of object
+     *
+     * @param Ctx<TObject> $ctx
+     *
+     * @return TObject
+     */
     private function resolveInjector(Config\Injectable $binding, Ctx $ctx, Tracer $tracer): object
     {
         $context = $ctx->context;
@@ -243,6 +250,7 @@ final class Actor
                 );
             }
 
+            /** @var TObject $instance */
             return $instance;
         } catch (TracedContainerException $e) {
             throw isset($injectorInstance) ? $e : $e::createWithTrace(\sprintf(
@@ -578,6 +586,13 @@ final class Actor
 
     /**
      * Register instance in container, might perform methods like auto-singletons, log populations, etc.
+     *
+     * @template TObject of object
+     *
+     * @param Ctx<TObject> $ctx
+     * @param TObject $instance
+     *
+     * @return TObject
      */
     private function registerInstance(Ctx $ctx, object $instance): object
     {
@@ -628,6 +643,12 @@ final class Actor
 
     /**
      * Find and run inflector
+     *
+     * @template TObject of object
+     *
+     * @param TObject $instance
+     *
+     * @return TObject
      */
     private function runInflector(object $instance): object
     {
@@ -640,6 +661,7 @@ final class Actor
                         $instance = $inflector->getParametersCount() > 1
                             ? $this->invoker->invoke($inflector->inflector, [$instance])
                             : ($inflector->inflector)($instance);
+                        /** @var TObject $instance */
                     }
                 }
             }

--- a/src/Core/src/Internal/Actor.php
+++ b/src/Core/src/Internal/Actor.php
@@ -658,10 +658,10 @@ final class Actor
             foreach ($this->state->inflectors as $class => $inflectors) {
                 if ($instance instanceof $class) {
                     foreach ($inflectors as $inflector) {
+                        /** @var TObject $instance */
                         $instance = $inflector->getParametersCount() > 1
                             ? $this->invoker->invoke($inflector->inflector, [$instance])
                             : ($inflector->inflector)($instance);
-                        /** @var TObject $instance */
                     }
                 }
             }

--- a/src/Core/src/Internal/Actor.php
+++ b/src/Core/src/Internal/Actor.php
@@ -193,7 +193,7 @@ final class Actor
         return $this->createInstance($ctx, $arguments, $fallbackActor, $tracer);
     }
 
-    private function resolveInjector(Config\Injectable $binding, Ctx $ctx, Tracer $tracer)
+    private function resolveInjector(Config\Injectable $binding, Ctx $ctx, Tracer $tracer): object
     {
         $context = $ctx->context;
         try {

--- a/src/Core/tests/SingletonsTest.php
+++ b/src/Core/tests/SingletonsTest.php
@@ -208,10 +208,7 @@ final class SingletonsTest extends TestCase
         };
     }
 
-    /**
-     * @return SampleClass
-     */
-    private function sampleClass()
+    private function sampleClass(): SampleClass
     {
         return new SampleClass();
     }

--- a/src/Queue/src/Bootloader/QueueBootloader.php
+++ b/src/Queue/src/Bootloader/QueueBootloader.php
@@ -129,7 +129,7 @@ final class QueueBootloader extends Bootloader
         ContainerInterface $container,
         FactoryInterface $factory,
         ContainerRegistry $registry,
-    ) {
+    ): QueueRegistry {
         return new QueueRegistry($container, $factory, $registry);
     }
 

--- a/src/Stempler/tests/BufferTest.php
+++ b/src/Stempler/tests/BufferTest.php
@@ -35,9 +35,9 @@ final class BufferTest extends TestCase
     public function testGetBytes(): void
     {
         $src = $this->buffer('abc');
-        self::assertEquals('abc', $src->nextBytes());
+        self::assertSame('abc', $src->nextBytes());
 
-        self::assertEquals('', $src->nextBytes());
+        self::assertSame('', $src->nextBytes());
     }
 
     public function testLookahead(): void
@@ -78,13 +78,13 @@ final class BufferTest extends TestCase
     public function testLookaheadByte(): void
     {
         $src = $this->buffer('abc');
-        self::assertEquals('a', $src->lookaheadByte());
+        self::assertSame('a', $src->lookaheadByte());
 
         self::assertEquals(new Byte(0, 'a'), $src->next());
-        self::assertEquals('b', $src->lookaheadByte());
+        self::assertSame('b', $src->lookaheadByte());
 
         self::assertEquals(new Byte(1, 'b'), $src->next());
-        self::assertEquals('c', $src->lookaheadByte());
+        self::assertSame('c', $src->lookaheadByte());
 
         self::assertEquals(new Byte(2, 'c'), $src->next());
         self::assertEquals(null, $src->lookaheadByte());
@@ -111,16 +111,16 @@ final class BufferTest extends TestCase
     public function testOffset(): void
     {
         $src = $this->buffer('abc');
-        self::assertEquals(0, $src->getOffset());
+        self::assertSame(0, $src->getOffset());
 
         self::assertEquals(new Byte(0, 'a'), $src->next());
-        self::assertEquals(0, $src->getOffset());
+        self::assertSame(0, $src->getOffset());
 
         self::assertEquals(new Byte(1, 'b'), $src->next());
-        self::assertEquals(1, $src->getOffset());
+        self::assertSame(1, $src->getOffset());
 
         self::assertEquals(new Byte(2, 'c'), $src->next());
-        self::assertEquals(2, $src->getOffset());
+        self::assertSame(2, $src->getOffset());
 
         $src = new Buffer($this->generateToken(new StringStream('abc')));
         self::assertEquals(new Token(0, null, 'a'), $src->next());
@@ -130,14 +130,14 @@ final class BufferTest extends TestCase
     public function testLookupBytes(): void
     {
         $src = $this->buffer('abc');
-        self::assertEquals(0, $src->getOffset());
+        self::assertSame(0, $src->getOffset());
 
-        self::assertEquals('ab', $src->lookaheadByte(2));
+        self::assertSame('ab', $src->lookaheadByte(2));
 
         self::assertEquals(new Byte(0, 'a'), $src->next());
 
-        self::assertEquals('bc', $src->lookaheadByte(2));
-        self::assertEquals('bc', $src->lookaheadByte(3));
+        self::assertSame('bc', $src->lookaheadByte(2));
+        self::assertSame('bc', $src->lookaheadByte(3));
 
         self::assertEquals(new Byte(1, 'b'), $src->next());
     }

--- a/src/Stempler/tests/BufferTest.php
+++ b/src/Stempler/tests/BufferTest.php
@@ -142,7 +142,7 @@ final class BufferTest extends TestCase
         self::assertEquals(new Byte(1, 'b'), $src->next());
     }
 
-    protected function buffer(string $string)
+    protected function buffer(string $string): Buffer
     {
         return new Buffer($this->generate(new StringStream($string)));
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `ReturnTypeFromReturnNewRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add return type to function like with return new.

It seems applied on final class or private method so should be safe.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually