### PR TITLE
Enable Rector TypeCoverageLevel 21

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(18)
+    ->withTypeCoverageLevel(21)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/src/Tokenizer/tests/InvocationsTest.php
+++ b/src/Tokenizer/tests/InvocationsTest.php
@@ -12,7 +12,7 @@ use Spiral\Tokenizer\Tokenizer;
 
 final class InvocationsTest extends TestCase
 {
-    protected function someFunction()
+    protected function someFunction(): void
     {
         $result = $this->sampleMethod('hello world');
         print_r(self::sampleMethod($result . 'plus'));
@@ -169,7 +169,7 @@ final class InvocationsTest extends TestCase
         self::assertSame('self::sampleMethod($result . \'plus\')', $invocation2->getSource());
     }
 
-    protected static function sampleMethod(string $string)
+    protected static function sampleMethod(string $string): void
     {
     }
 

--- a/src/Tokenizer/tests/ReflectionFileTest.php
+++ b/src/Tokenizer/tests/ReflectionFileTest.php
@@ -107,7 +107,7 @@ final class ReflectionFileTest extends TestCase
         ], $reflection->getInterfaces());
     }
 
-    private function deadend()
+    private function deadend(): void
     {
         $a = $b = null;
         test_function_a($this, $a + $b);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `AddVoidReturnTypeWhereNoReturnRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add return type void to function like without any return.

It seems applied on final class or private method so should be safe.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually