### PR TITLE
Enable Rector TypeCoverageLevel 23

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -147,7 +147,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
         ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false,
     ])
-    ->withTypeCoverageLevel(21)
+    ->withTypeCoverageLevel(23)
     ->withRules([
         ClosureReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,

--- a/tests/app/src/Controller/TestController.php
+++ b/tests/app/src/Controller/TestController.php
@@ -47,7 +47,7 @@ class TestController
         throw new \InvalidArgumentException('Invalid argument');
     }
 
-    public function route(RouteInterface $route)
+    public function route(RouteInterface $route): ?array
     {
         return $route->getMatches();
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Applied rule: `ReturnNullableTypeRector`.

<!-- Describe what has changed in this PR -->

## Why?

We can add  `?nullabl`e type to class methods and functions

It seems applied on final class or private method so should be safe.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually