### PR TITLE
Fix undefined class Spiral\Bootloader\Attributes\AttributesBootloader on tokenizer split repo test

### DIFF
--- a/src/Tokenizer/composer.json
+++ b/src/Tokenizer/composer.json
@@ -44,6 +44,7 @@
         "spiral/attributes": "^2.8|^3.0",
         "spiral/boot": "^3.17",
         "spiral/files": "^3.17",
+        "spiral/framework": "^3.17",
         "phpunit/phpunit": "^10.5.41",
         "vimeo/psalm": "^6.0"
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix test error on split repo:

```

Run vendor/bin/phpunit --coverage-clover=coverage.clover
PHPUnit 10.5.63 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.34
Configuration: /home/runner/work/tokenizer/tokenizer/phpunit.xml

...................................................[Spiral\Boot\Exception\ClassNotFoundException]
Bootloader class `Spiral\Bootloader\Attributes\AttributesBootloader` does not exist. in vendor/spiral/boot/src/BootloadManager/Checker/ClassExistsChecker.php:23
E...........  63 / 120 ( 52%)

```

Ref https://github.com/spiral/tokenizer/actions/runs/27914965694/job/82598575223#step:15:15

<!-- Describe what has changed in this PR -->

## Why?

To avoid error, this need to be added to composer.json split repo, I added to `require-dev`

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
