### PR TITLE
Use @psalm-import-type over @phpstan-import-type on Bootloader

### DIFF
--- a/src/Boot/src/Bootloader/Bootloader.php
+++ b/src/Boot/src/Bootloader/Bootloader.php
@@ -13,7 +13,7 @@ namespace Spiral\Boot\Bootloader;
  * Attention, you are able to define your own set of shared (short bindings) components in your
  * bootloader, DO NOT share your business models this way - use regular DI.
  *
- * @phpstan-import-type TConstantBinding from BootloaderInterface
+ * @psalm-import-type TConstantBinding from BootloaderInterface
  */
 abstract class Bootloader implements BootloaderInterface, DependedInterface
 {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Change `@psalm-import-type` over `@phpstan-import-type` on `Bootloader`

<!-- Describe what has changed in this PR -->

## Why?

psalm is used on static analysis.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
