### PR TITLE
Bump Rector to ~2.5.3 and re-run it with cleaned up skip configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.5.2",
+        "rector/rector": "~2.5.3",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/rector.php
+++ b/rector.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
-use Rector\DeadCode\Rector\Expression\RemoveDeadStmtRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
@@ -41,22 +39,14 @@ return RectorConfig::configure()
         RemoveUnusedPrivateMethodRector::class => [
             __DIR__ . '/src/Translator/tests/IndexerTest.php',
             __DIR__ . '/src/Tokenizer/tests/ReflectionFileTest.php',
-            __DIR__ . '/src/Core/tests/SingletonsTest.php',
         ],
         RemoveAlwaysTrueIfConditionRector::class => [
-            __DIR__ . '/src/Bridge/Stempler/src/StemplerEngine.php',
             // Keep the is_string() guard: getBindings() reads user config, so a
             // malformed (non-string) binding must be skipped, not crash class_exists().
             __DIR__ . '/src/Prototype/src/Bootloader/PrototypeBootloader.php',
         ],
         RemoveUnusedPrivateMethodParameterRector::class => [
             __DIR__ . '/src/Core/tests/InjectableTest.php',
-        ],
-        RemoveDoubleAssignRector::class => [
-            __DIR__ . '/src/Core/tests/Scope/FinalizeAttributeTest.php',
-        ],
-        RemoveDeadStmtRector::class => [
-            __DIR__ . '/src/Core/tests/ExceptionsTest.php',
         ],
 
         // to be enabled later for bc break 4.x
@@ -87,7 +77,6 @@ return RectorConfig::configure()
         ],
 
         ArrayToFirstClassCallableRector::class => [
-            __DIR__ . '/src/Core/tests/InjectableTest.php',
             __DIR__ . '/src/Core/tests/InvokerTest.php',
         ],
 
@@ -97,10 +86,9 @@ return RectorConfig::configure()
             __DIR__ . '/src/Models/tests/PublicEntity.php',
         ],
 
-        \Rector\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector::class => [
-            // test 2 versions of monolog: v2 and v3 which
-            // Logger::API can be 2 or 3
-            __DIR__ . '/src/Bridge/Monolog/tests/HandlersTest.php',
+        TypedPropertyFromAssignsRector::class => [
+            // casted value
+            __DIR__ . '/src/Models/tests/NameValue.php'
         ],
 
         // to be enabled later for easier to review
@@ -108,6 +96,9 @@ return RectorConfig::configure()
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector::class,
         \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector::class,
         \Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector::class,
+
+        \Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector::class,
+        \Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector::class,
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(deadCode: true, phpunitCodeQuality: true)

--- a/src/Exceptions/src/Renderer/ConsoleRenderer.php
+++ b/src/Exceptions/src/Renderer/ConsoleRenderer.php
@@ -218,7 +218,7 @@ class ConsoleRenderer extends AbstractRenderer
         if (!$this->colorsSupport) {
             $format = \preg_replace('/<[^>]+>/', '', $format);
         } else {
-            $format = \preg_replace_callback('/(<([^>]+)>)/', static function ($partial) {
+            $format = \preg_replace_callback('/(<([^>]+)>)/', static function ($partial): string {
                 $style = '';
                 foreach (\explode(',', \trim($partial[2], '/')) as $color) {
                     if (isset(self::COLORS[$color])) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR:

- Bump Rector to 2.5.3
- Re-run it to apply more on add return type on closures
- skip various new rules to be discussed later in separate PRs.
- clean up no longer needed skip configs.

<!-- Describe what has changed in this PR -->

## Why?

unused skip configs no longer needed, and applied obvious return type on closures.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
