### PR TITLE
Enable RemoveUselessUnionReturnDocblockRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -97,7 +97,6 @@ return RectorConfig::configure()
         \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector::class,
         \Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector::class,
 
-        \Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector::class,
         \Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector::class,
     ])
     ->withPhpSets(php81: true)

--- a/src/Router/src/Traits/DefaultsTrait.php
+++ b/src/Router/src/Traits/DefaultsTrait.php
@@ -12,8 +12,6 @@ trait DefaultsTrait
 
     /**
      * Returns new route instance with forced default values.
-     *
-     * @return RouteInterface|$this
      */
     public function withDefaults(array $defaults): RouteInterface
     {

--- a/src/Router/src/Traits/PipelineTrait.php
+++ b/src/Router/src/Traits/PipelineTrait.php
@@ -35,7 +35,6 @@ trait PipelineTrait
      * $route->withMiddleware([ProxyMiddleware::class, OtherMiddleware::class]);
      *
      * @param MiddlewareType|array{0:MiddlewareType[]} ...$middleware
-     * @return RouteInterface|$this
      *
      * @throws RouteException
      */


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR enable `RemoveUselessUnionReturnDocblockRector` that remove useless union docblock, applied changes are on trait.

## Why?

If return type is already object type on trait and return is cloned of `$this`, union to `$this` is not needed.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
