### PR TITLE
Fix session id validation and file handler path containment

### DIFF
--- a/src/Session/src/Handler/FileHandler.php
+++ b/src/Session/src/Handler/FileHandler.php
@@ -64,10 +64,11 @@ final class FileHandler implements \SessionHandlerInterface
 
     /**
      * Session data filename.
-     * @param mixed $id
      */
-    protected function getFilename($id): string
+    protected function getFilename(string $id): string
     {
-        return \sprintf('%s/%s', $this->directory, $id);
+        // basename() strips any '/' and '..', so a crafted id can never leave $directory,
+        // even if some other caller reaches this method with an unvalidated id.
+        return \sprintf('%s/%s', $this->directory, \basename($id));
     }
 }

--- a/src/Session/src/Session.php
+++ b/src/Session/src/Session.php
@@ -204,6 +204,6 @@ final class Session implements SessionInterface
      */
     private function validID(string $id): bool
     {
-        return \preg_match('/^[-,a-zA-Z0-9]{1,128}$/', $id) !== false;
+        return \preg_match('/^[-,a-zA-Z0-9]{1,128}$/', $id) === 1;
     }
 }

--- a/src/Session/tests/SecurityTest.php
+++ b/src/Session/tests/SecurityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Session;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Spiral\Files\Files;
+use Spiral\Session\Handler\FileHandler;
+use Spiral\Session\Session;
+
+final class SecurityTest extends TestCase
+{
+    private string $directory;
+
+    public static function maliciousIds(): iterable
+    {
+        yield 'parent traversal' => ['../../public/shell.php'];
+        yield 'single traversal' => ['../evil.txt'];
+        yield 'nested slash' => ['foo/bar'];
+        yield 'leading slash (absolute)' => ['/etc/passwd'];
+        yield 'null byte' => ["ok\0../evil"];
+        yield 'newline' => ["ok\n../evil"];
+    }
+
+    /**
+     * The id allowlist must reject any id that leaves the [-,a-zA-Z0-9] character class.
+     * On the vulnerable code preg_match(...) !== false is true for 0, so the traversal id
+     * is accepted and getID() returns it verbatim.
+     */
+    #[DataProvider('maliciousIds')]
+    public function testValidIdRejectsMaliciousSessionId(string $maliciousId): void
+    {
+        $session = new Session('sig', 86400, $maliciousId);
+
+        self::assertNull(
+            $session->getID(),
+            \sprintf('Session accepted invalid id %s; the id allowlist is inert.', \var_export($maliciousId, true)),
+        );
+    }
+
+    /**
+     * A legitimate id (only [-,a-zA-Z0-9]) must still be accepted after the fix.
+     */
+    public function testValidIdStillAcceptsLegitimateSessionId(): void
+    {
+        $id = 'abc-123,DEF';
+        $session = new Session('sig', 86400, $id);
+
+        self::assertSame($id, $session->getID());
+    }
+
+    /**
+     * The default file handler must never write outside its configured directory, even when it
+     * is handed a crafted id. On the vulnerable code the file lands in the parent directory.
+     */
+    public function testFileHandlerDoesNotEscapeSessionDirectory(): void
+    {
+        $files = new Files();
+        $sessionDir = $this->directory . '/runtime/session';
+        $files->ensureDirectory($sessionDir);
+
+        $handler = new FileHandler($files, $sessionDir);
+
+        $handler->write('../../public/shell.php', '<?php echo "pwned"; ?>');
+
+        $escaped = $this->directory . '/public/shell.php';
+        self::assertFileDoesNotExist(
+            $escaped,
+            'FileHandler wrote outside the session directory - path traversal is possible.',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->directory = \sys_get_temp_dir() . '/spiral_session_security_' . \getmypid() . '_' . \uniqid();
+        \mkdir($this->directory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        (new Files())->deleteDirectory($this->directory, true);
+        if (\is_dir($this->directory)) {
+            @\rmdir($this->directory);
+        }
+    }
+}


### PR DESCRIPTION
## What was changed

- `Session::validID()` now compares the `preg_match()` result with `=== 1` instead of `!== false`. `preg_match()` returns `1` on match, `0` on no match and `false` only on an engine error, so `!== false` was true for `0` as well and the id allowlist accepted every string. With `=== 1` a non-matching id is rejected, as originally intended.
- `FileHandler::getFilename()` now wraps the id in `basename()` when building the on-disk path, so an id can no longer contain path separators or `..` segments and always stays inside the configured session directory.
- Added `SecurityTest` covering both changes: crafted ids (traversal, slashes, absolute paths, null byte, newline) are rejected, a legitimate id is still accepted, and the file handler never writes outside its directory.

## Why?

The session id comes straight from the client-supplied cookie. Because the allowlist in `validID()` was inert, any value was accepted and used verbatim as the id, and `FileHandler` concatenated it into the file path without any containment. A crafted id could therefore make the handler read from and write session files outside the configured `runtime/session` directory, creating any missing parent directories along the way — an unauthenticated arbitrary file write.

Fixing the comparison restores the intended validation and is sufficient on its own; the `basename()` change is defense in depth so the handler stays safe even if some other caller reaches it with an unvalidated id. Both changes are one-liners and do not affect legitimate ids, which only ever contain `[-,a-zA-Z0-9]`.

## Checklist

- Closes #
- Tested
    - [ ] Tested manually
    - [x] Unit tests added
