### PR TITLE
Bump Rector to ~2.5.7 and re-run it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.5.5",
+        "rector/rector": "~2.5.7",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/rector.php
+++ b/rector.php
@@ -95,6 +95,10 @@ return RectorConfig::configure()
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\WithCallbackIdenticalToStandaloneAssertsRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector::class,
         \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector::class,
+
+        \Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector::class => [
+            __DIR__ . '/src/Router/src/Traits/VerbsTrait.php',
+        ],
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(deadCode: true, phpunitCodeQuality: true)

--- a/src/Router/src/Traits/VerbsTrait.php
+++ b/src/Router/src/Traits/VerbsTrait.php
@@ -14,7 +14,6 @@ trait VerbsTrait
     /**
      * Attach specific list of HTTP verbs to the route.
      *
-     * @return $this
      * @throws RouteException
      */
     public function withVerbs(string ...$verbs): RouteInterface

--- a/src/Router/src/Traits/VerbsTrait.php
+++ b/src/Router/src/Traits/VerbsTrait.php
@@ -14,6 +14,7 @@ trait VerbsTrait
     /**
      * Attach specific list of HTTP verbs to the route.
      *
+     * @return $this
      * @throws RouteException
      */
     public function withVerbs(string ...$verbs): RouteInterface


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR bump Rector to ~2.5.7 and re-run it

<!-- Describe what has changed in this PR -->

## Why?

Applied skip removal of `@return $this` on `VerbsTrait` via `RemoveReturnTagIncompatibleWithNativeTypeRector` which on purpose.

to avoid notice:

```
<file name="src/AnnotatedRoutes/src/RouteLocatorListener.php">
 <error line="74" column="75" severity="error" message="UndefinedMethod: Method Spiral\Router\AbstractRoute::withMiddleware does not exist"/>
</file>
```

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually

## Documentation <!--- Remove if not needed -->
