### PR TITLE
Bump Rector to ~2.5.8 and skip new rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.5.7",
+        "rector/rector": "~2.5.8",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/rector.php
+++ b/rector.php
@@ -95,10 +95,8 @@ return RectorConfig::configure()
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\WithCallbackIdenticalToStandaloneAssertsRector::class,
         \Rector\PHPUnit\CodeQuality\Rector\MethodCall\SimplerWithIsInstanceOfRector::class,
         \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector::class,
-
-        \Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector::class => [
-            __DIR__ . '/src/Router/src/Traits/VerbsTrait.php',
-        ],
+        \Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector::class,
+        \Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector::class,
     ])
     ->withPhpSets(php81: true)
     ->withPreparedSets(deadCode: true, phpunitCodeQuality: true)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR bump Rector to ~2.5.8 and skip new rules

<!-- Describe what has changed in this PR -->

## Why?

The skipped rules are because currently still buggy or needs some separate PR to ease for review, eg the `RemoveDefaultValueFromAssignedPropertyRector` is buggy on non-final class on protected property, fix is on the way on rector side:

- https://github.com/rectorphp/rector-src/pull/8214 

Here skip for now.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually

## Documentation <!--- Remove if not needed -->
