### PR TITLE
Bump Rector to ~2.6.1 and re-run it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.5.8",
+        "rector/rector": "~2.6.1",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/src/Security/tests/PermissionManagerTest.php
+++ b/src/Security/tests/PermissionManagerTest.php
@@ -70,7 +70,7 @@ final class PermissionManagerTest extends TestCase
 
         $this->rules->method('has')->willReturn(true);
         $this->rules->method('get')
-            ->willReturnCallback(static function (...$args) use (&$series) {
+            ->willReturnCallback(static function (...$args) use (&$series): ForbidRule|AllowRule {
                 [$expectedArgs, $return] = \array_shift($series);
                 self::assertSame($expectedArgs, $args);
 

--- a/src/Tokenizer/src/Config/TokenizerConfig.php
+++ b/src/Tokenizer/src/Config/TokenizerConfig.php
@@ -22,7 +22,7 @@ final class TokenizerConfig extends InjectableConfig
 
     /**
      * @var array{
-     *     cache: array{directory: null, enabled: bool},
+     *     cache: array{directory: string|null, enabled: bool},
      *     load: array{classes:bool, enums: bool, interfaces: bool},
      *     debug: bool,
      *     directories: TDirectories,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR bump Rector to ~2.6.1 and apply rector re-run.

<!-- Describe what has changed in this PR -->

## Why?

Changed parts:

- fix invalid docblock due to allowed directory value in array docblock (manually apply due to rector run apply invalid change to change return type instead), the fix is in the way:

- https://github.com/rectorphp/rector-src/pull/8282

- add return type on willReturnCallback() that apply `ClosureReturnTypeRector`.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually

## Documentation <!--- Remove if not needed -->
