### PR TITLE
[Stempler] Encode on* attribute output as a JavaScript literal

### DIFF
--- a/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
+++ b/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
@@ -133,7 +133,7 @@ final class DynamicToPHP implements VisitorInterface
             return \sprintf(
                 'json_encode(%s, %s, %s)',
                 '%s',
-                'JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT',
+                'JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE',
                 '512',
             );
         }

--- a/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
+++ b/src/Stempler/src/Transform/Finalizer/DynamicToPHP.php
@@ -138,9 +138,19 @@ final class DynamicToPHP implements VisitorInterface
             );
         }
 
-        // in on* and other attributes
+        // php {{ }} in on* event handlers. The browser HTML-decodes the attribute value before the JS engine
+        // parses it, so the value must survive both decodings: encode it as a JavaScript literal first, then
+        // HTML-encode the surrounding quotes. The JSON_HEX_* flags leave no HTML-special character inside the
+        // literal, so the outer htmlspecialchars() only affects the delimiters.
+        // JSON_INVALID_UTF8_SUBSTITUTE mirrors ENT_SUBSTITUTE: broken input yields U+FFFD instead of making
+        // json_encode() return false and collapse the whole value to an empty string.
         if ($context[0] instanceof Verbatim && $context[1] instanceof Attr && $context[1]->name !== 'style') {
-            return \sprintf("'%s', %s, '%s'", '&quot;', $this->defaultFilter, '&quot;');
+            return \sprintf(
+                "htmlspecialchars(json_encode(%s, %s, %s), ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8')",
+                '%s',
+                'JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE',
+                '512',
+            );
         }
 
         return $this->defaultFilter;

--- a/src/Stempler/tests/Transform/DynamicToPHPTest.php
+++ b/src/Stempler/tests/Transform/DynamicToPHPTest.php
@@ -117,7 +117,8 @@ final class DynamicToPHPTest extends BaseTestCase
     public function testVerbatim3(): void
     {
         self::assertSame('<script>alert(<?php echo json_encode'
-        . '("hello world", JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT, 512); ?>)</script>', $res = $this->compile('<script>alert({{ "hello world" }})</script>')->getContent());
+        . '("hello world", JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT '
+        . '| JSON_INVALID_UTF8_SUBSTITUTE, 512); ?>)</script>', $res = $this->compile('<script>alert({{ "hello world" }})</script>')->getContent());
 
         self::assertSame('<script>alert("hello world")</script>', $this->eval($res));
     }
@@ -125,9 +126,21 @@ final class DynamicToPHPTest extends BaseTestCase
     public function testVerbatim4(): void
     {
         self::assertSame('<script>alert(<?php echo json_encode' .
-        '("hello\' \'world", JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT, 512); ?>)</script>', $res = $this->compile('<script>alert({{ "hello\' \'world" }})</script>')->getContent());
+        '("hello\' \'world", JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT '
+        . '| JSON_INVALID_UTF8_SUBSTITUTE, 512); ?>)</script>', $res = $this->compile('<script>alert({{ "hello\' \'world" }})</script>')->getContent());
 
         self::assertSame('<script>alert("hello\u0027 \u0027world")</script>', $this->eval($res));
+    }
+
+    /**
+     * Without JSON_INVALID_UTF8_SUBSTITUTE json_encode() returns false on broken input and the value collapses
+     * to an empty string, silently changing the arity of the surrounding JavaScript call.
+     */
+    public function testVerbatimScriptSubstitutesInvalidUtf8(): void
+    {
+        $res = $this->compile('<script>alert({{ chr(177) . \'1\' }})</script>')->getContent();
+
+        self::assertSame('<script>alert("\ufffd1")</script>', $this->eval($res));
     }
 
     protected function getVisitors(): array

--- a/src/Stempler/tests/Transform/DynamicToPHPTest.php
+++ b/src/Stempler/tests/Transform/DynamicToPHPTest.php
@@ -66,10 +66,52 @@ final class DynamicToPHPTest extends BaseTestCase
 
     public function testVerbatim2(): void
     {
-        self::assertSame('<a onclick="alert(<?php echo \'&quot;\', '
-        . 'htmlspecialchars((string) ("hello world"), ENT_QUOTES | ENT_SUBSTITUTE, \'utf-8\'), \'&quot;\'; ?>)"></a>', $res = $this->compile('<a onclick="alert({{ "hello world" }})"></a>')->getContent());
+        self::assertSame('<a onclick="alert(<?php echo htmlspecialchars(json_encode('
+        . '"hello world", JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT '
+        . '| JSON_INVALID_UTF8_SUBSTITUTE, 512), '
+        . 'ENT_QUOTES | ENT_SUBSTITUTE, \'utf-8\'); ?>)"></a>', $res = $this->compile('<a onclick="alert({{ "hello world" }})"></a>')->getContent());
 
         self::assertSame('<a onclick="alert(&quot;hello world&quot;)"></a>', $this->eval($res));
+    }
+
+    /**
+     * An event handler attribute is JavaScript delivered inside HTML: the browser HTML-decodes the value before
+     * the JS engine parses it. Quotes therefore have to be JavaScript escapes; HTML entities would decode back
+     * into real quotes and end the string literal early.
+     */
+    public function testVerbatimEventHandlerEscapesQuotesForJavaScript(): void
+    {
+        // chr(34) keeps the double quote out of the template itself, where it would close the attribute
+        $res = $this->compile('<a onclick="alert({{ chr(34) . \'hi\' . chr(34) }})"></a>')->getContent();
+
+        self::assertSame(
+            '<a onclick="alert(&quot;\u0022hi\u0022&quot;)"></a>',
+            $rendered = $this->eval($res),
+        );
+
+        // what the JS engine parses, once the browser has decoded the attribute value
+        self::assertSame(
+            'alert("\u0022hi\u0022")',
+            $this->decodeEventHandler($rendered, 'onclick'),
+        );
+    }
+
+    public function testVerbatimEventHandlerKeepsNonStringTypes(): void
+    {
+        $res = $this->compile('<a onclick="alert({{ 123 }})"></a>')->getContent();
+
+        self::assertSame('<a onclick="alert(123)"></a>', $this->eval($res));
+    }
+
+    /**
+     * Broken input must degrade the way ENT_SUBSTITUTE does, not make json_encode() return false and silently
+     * collapse the value to an empty string.
+     */
+    public function testVerbatimEventHandlerSubstitutesInvalidUtf8(): void
+    {
+        $res = $this->compile('<a onclick="alert({{ chr(177) . \'1\' }})"></a>')->getContent();
+
+        self::assertSame('<a onclick="alert(&quot;\ufffd1&quot;)"></a>', $this->eval($res));
     }
 
     public function testVerbatim3(): void
@@ -103,5 +145,16 @@ final class DynamicToPHPTest extends BaseTestCase
         eval('?>' . $body);
 
         return \ob_get_clean();
+    }
+
+    /**
+     * Emulates the browser: the HTML parser decodes entities in an attribute value, and the JS engine parses
+     * the decoded result.
+     */
+    private function decodeEventHandler(string $html, string $attribute): string
+    {
+        \preg_match('/' . \preg_quote($attribute, '/') . '="([^"]*)"/', $html, $matches);
+
+        return \html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5, 'utf-8');
     }
 }


### PR DESCRIPTION
## What was changed

Context-aware escaping now encodes both JavaScript contexts as JavaScript literals.

**`on*` attributes** were encoded with `htmlspecialchars()` and wrapped in literal `&quot;`. They are now encoded with the same `JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT` flags already used for `<script>`, with the delimiters HTML-encoded afterwards.

**Invalid UTF-8** no longer collapses the value: `JSON_INVALID_UTF8_SUBSTITUTE` was added to the `on*` branch (first commit) and to the `<script>` branch (second commit).

Three existing assertions on compiled PHP were updated, and four cases were added to `DynamicToPHPTest`.

## Why?

An `on*` attribute value is JavaScript delivered inside HTML, so the browser HTML-decodes it *before* the JS engine parses it. HTML-entity encoding therefore does not hold: `&quot;` and `&#039;` decode back into real quotes, and a quote in the value ends the JavaScript string literal instead of remaining part of it. The `JSON_HEX_*` flags leave no HTML-special character inside the literal, so the value survives both decoding passes — and the outer `htmlspecialchars()` is left with nothing to encode except the surrounding quotes.

This branch is reached for event handlers exclusively, which is why the fix is scoped to them: `HTMLSyntax` marks only `on*` and `style` attribute values as `Verbatim`, and `style` is excluded by the branch condition. Ordinary attributes (`title`, `href`, `data-*`) keep the plain `htmlspecialchars()` filter, where HTML-entity encoding is the correct choice.

Separately, `json_encode()` returns `false` on malformed UTF-8, so the compiled template echoed an empty string and the value vanished from the emitted JavaScript, silently changing the arity of the surrounding call. `JSON_INVALID_UTF8_SUBSTITUTE` mirrors the `ENT_SUBSTITUTE` the default filter has always used.

Rendered output is unchanged for values that needed no encoding — `{{ "hello world" }}` in an `onclick` still renders `alert(&quot;hello world&quot;)` — so only the compiled PHP differs.

## Checklist

- Closes #
- Tested
    - [x] Tested manually
    - [x] Unit tests added

Manual testing covered both branches across strings, quotes, apostrophes, integers, floats, `null`, booleans, lists, associative arrays, non-ASCII text, and malformed UTF-8, comparing the rendered attribute against what a browser yields after HTML-entity decoding. A byte-by-byte sweep confirmed that no HTML-special character survives `json_encode()` with these flags, so the outer `htmlspecialchars()` cannot double-encode: values round-trip back to the original through `html_entity_decode()` + `json_decode()`, including already-encoded input such as `&amp;`.

## Documentation

The "Context-Aware escaping" section of `docs/en/views/stempler.md` documents only `<script>`; it is worth extending with the `on*` case now that both contexts use JavaScript encoding.
