### PR TITLE
Bump Rector to ~2.6.2 and re-run it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5.41",
         "ramsey/collection": "^1.3",
-        "rector/rector": "~2.6.1",
+        "rector/rector": "~2.6.2",
         "spiral/code-style": "^2.2.2",
         "spiral/nyholm-bridge": "^1.3",
         "spiral/testing": "^2.12",

--- a/src/Broadcasting/tests/Middleware/AuthorizationMiddlewareTest.php
+++ b/src/Broadcasting/tests/Middleware/AuthorizationMiddlewareTest.php
@@ -193,7 +193,7 @@ final class AuthorizationMiddlewareTest extends TestCase
         $dispatcher->shouldReceive('dispatch')
             ->once()
             ->withArgs(
-                static fn(Authorized $event): bool => $event->status->success === true
+                static fn(Authorized $event): bool => $event->status->success
                 && $event->status->topics === null
                 && $event->status->response === null,
             );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR bump Rector to ~2.6.2 and re-run it, and apply a rule: `SimplifyBoolIdenticalTrueRector`

<!-- Describe what has changed in this PR -->

## Why?

`SimplifyBoolIdenticalTrueRector` can clean up `=== true` check if already native typed `bool`.

<!-- Tell your future self why have you made these changes -->

## Checklist

- Tested
    - [x] Tested manually
